### PR TITLE
Fix manager permission

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,12 @@ rules:
   verbs:
   - list
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - dashboard.gardener.cloud
   resources:
   - terminals

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -79,6 +79,7 @@ func (r *TerminalReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=dashboard.gardener.cloud,resources=terminals,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dashboard.gardener.cloud,resources=terminals/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs=list


### PR DESCRIPTION
**What this PR does / why we need it**:
The permission to `create` `subjectaccessreviews` is missing on the `terminal-manager-role`.
The permission is needed for the terminal validation (e.g. to check if the user, that has created the terminal resource, has the permission to read the referenced secret)

**Which issue(s) this PR fixes**:
Fixes #23 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
