### PR TITLE
Adapt labels/annotations to the new API group

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -30,4 +30,5 @@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 cd "$SOURCE_PATH"
 
-golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*" --verbose --timeout 2m
+# TODO remove exlusion "deprecated" checks in Makefile and .ci/check once deprecated fields GardenCreatedByDeprecated and TerminalLastHeartbeatDeprecated are removed
+golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"  --exclude ".*deprecated.*" --verbose --timeout 2m

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ manifests: controller-gen
 
 # Run golangci-lint against code
 lint: $(GOPATH)/bin/golangci-lint
-	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"
+# TODO remove exlusion "deprecated" checks in Makefile and .ci/check once deprecated fields GardenCreatedByDeprecated and TerminalLastHeartbeatDeprecated are removed
+	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*" --exclude ".*deprecated.*"
 
 $(GOPATH)/bin/golangci-lint:
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -177,7 +177,7 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 		return nil, errors.New("target namespace not set")
 	}
 
-	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 {
+	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 && len(t.ObjectMeta.Annotations[GardenCreatedByDeprecated]) == 0 {
 		return nil, errors.New("createdBy annotation not set")
 	}
 
@@ -186,16 +186,21 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 		return nil, err
 	}
 
-	createdByHash, err := utils.ToFnvHash(t.ObjectMeta.Annotations["garden.sapcloud.io/createdBy"])
+	createdBy := t.ObjectMeta.Annotations[GardenCreatedByDeprecated]
+	if len(createdBy) == 0 {
+		createdBy = t.ObjectMeta.Annotations[GardenCreatedBy]
+	}
+
+	createdByHash, err := utils.ToFnvHash(createdBy)
 	if err != nil {
 		return nil, err
 	}
 
 	return &labels.Set{
 		Component: TerminalComponent,
-		"terminal.dashboard.gardener.cloud/identifier":    t.Spec.Identifier,
-		"terminal.dashboard.gardener.cloud/targetNsHash":  targetNamespace,
-		"terminal.dashboard.gardener.cloud/createdByHash": createdByHash,
+		"terminal.dashboard.gardener.cloud/identifier":      t.Spec.Identifier,
+		"terminal.dashboard.gardener.cloud/target-ns-hash":  targetNamespace,
+		"terminal.dashboard.gardener.cloud/created-by-hash": createdByHash,
 	}, nil
 }
 
@@ -212,11 +217,23 @@ const (
 
 	// GardenCreatedBy is the key for an annotation of a terminal resource whose value contains the username
 	// of the user that created the resource.
-	GardenCreatedBy = "garden.sapcloud.io/createdBy"
+	GardenCreatedBy = "gardener.cloud/created-by"
 
 	// GardenCreatedBy is the key for an annotation of a terminal resource whose value contains the username
 	// of the user that created the resource.
-	TerminalLastHeartbeat = "dashboard.gardener.cloud/lastHeartbeatAt"
+	//
+	// Deprecated: Use `GardenCreatedBy` instead.
+	GardenCreatedByDeprecated = "garden.sapcloud.io/createdBy"
+
+	// TerminalLastHeartbeat is the key for an annotation of a terminal resource whose value contains the username
+	// of the user that created the resource.
+	TerminalLastHeartbeat = "dashboard.gardener.cloud/last-heartbeat-at"
+
+	// TerminalLastHeartbeat is the key for an annotation of a terminal resource whose value contains the username
+	// of the user that created the resource.
+	//
+	// Deprecated: Use `TerminalLastHeartbeat` instead.
+	TerminalLastHeartbeatDeprecated = "dashboard.gardener.cloud/lastHeartbeatAt"
 
 	// ShootOperation is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.
 	TerminalOperation = "dashboard.gardener.cloud/operation"

--- a/controllers/terminalheartbeat_controller.go
+++ b/controllers/terminalheartbeat_controller.go
@@ -66,7 +66,11 @@ func (r *TerminalHeartbeatReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, nil
 	}
 
-	lastHeartbeat := t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeat]
+	lastHeartbeat := t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeatDeprecated]
+	if len(lastHeartbeat) == 0 {
+		lastHeartbeat = t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeat]
+	}
+
 	if len(lastHeartbeat) == 0 {
 		// if there is no heartbeat set, delete right away
 		return ctrl.Result{}, r.deleteTerminal(ctx, t)

--- a/webhooks/mutating/terminal_create_update_handler.go
+++ b/webhooks/mutating/terminal_create_update_handler.go
@@ -46,6 +46,7 @@ func (h *TerminalMutator) mutatingTerminalFn(ctx context.Context, t *v1alpha1.Te
 
 	if admissionReq.Operation == v1beta1.Create {
 		t.ObjectMeta.Annotations[v1alpha1.GardenCreatedBy] = admissionReq.UserInfo.Username
+		t.ObjectMeta.Annotations[v1alpha1.GardenCreatedByDeprecated] = admissionReq.UserInfo.Username
 
 		uuidString := uuid.NewV4().String()
 
@@ -62,11 +63,13 @@ func (h *TerminalMutator) mutatingTerminalFn(ctx context.Context, t *v1alpha1.Te
 		h.mutateNamespaceIfTemporary(t, terminalIdentifier)
 
 		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] = time.Now().UTC().Format(time.RFC3339)
+		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	if t.ObjectMeta.Annotations[v1alpha1.TerminalOperation] == v1alpha1.TerminalOperationKeepalive {
 		delete(t.ObjectMeta.Annotations, v1alpha1.TerminalOperation)
 		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] = time.Now().UTC().Format(time.RFC3339)
+		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt labels/annotations to the new API group.

`garden.sapcloud.io/createdBy` -> `gardener.cloud/created-by`
`dashboard.gardener.cloud/lastHeartbeatAt` -> `dashboard.gardener.cloud/last-heartbeat-at`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
