### PR TITLE
Annotate resources with created-by and target-ns info

### DIFF
--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -268,7 +268,7 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 		return nil, errors.New("createdBy annotation not set")
 	}
 
-	targetNamespace, err := utils.ToFnvHash(*t.Spec.Target.Namespace)
+	targetNamespaceHash, err := utils.ToFnvHash(*t.Spec.Target.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -286,8 +286,30 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 	return &labels.Set{
 		Component: TerminalComponent,
 		"terminal.dashboard.gardener.cloud/identifier":      t.Spec.Identifier,
-		"terminal.dashboard.gardener.cloud/target-ns-hash":  targetNamespace,
+		"terminal.dashboard.gardener.cloud/target-ns-hash":  targetNamespaceHash,
 		"terminal.dashboard.gardener.cloud/created-by-hash": createdByHash,
+	}, nil
+}
+
+func (t *Terminal) NewAnnotationsSet() (*utils.Set, error) {
+	if t.Spec.Target.Namespace == nil {
+		return nil, errors.New("target namespace not set")
+	}
+
+	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 && len(t.ObjectMeta.Annotations[GardenCreatedByDeprecated]) == 0 {
+		return nil, errors.New("createdBy annotation not set")
+	}
+
+	targetNamespace := *t.Spec.Target.Namespace
+
+	createdBy := t.ObjectMeta.Annotations[GardenCreatedByDeprecated]
+	if len(createdBy) == 0 {
+		createdBy = t.ObjectMeta.Annotations[GardenCreatedBy]
+	}
+
+	return &utils.Set{
+		"terminal.dashboard.gardener.cloud/target-ns":  targetNamespace,
+		"terminal.dashboard.gardener.cloud/created-by": createdBy,
 	}, nil
 }
 

--- a/utils/miscellaneous.go
+++ b/utils/miscellaneous.go
@@ -20,6 +20,9 @@ import (
 	"hash/fnv"
 )
 
+// Set is a map of label:value. It implements Labels.
+type Set map[string]string
+
 func ToFnvHash(value string) (string, error) {
 	fnvHash := fnv.New64a()
 
@@ -29,4 +32,28 @@ func ToFnvHash(value string) (string, error) {
 	}
 
 	return fmt.Sprint(fnvHash.Sum64()), nil
+}
+
+// MergeStringMap combines given maps, and does not check for any conflicts
+// between the maps. In case of conflicts, second map (map2) wins
+func MergeStringMap(oldMap Set, newMap Set) Set {
+	var out map[string]string
+
+	if oldMap != nil {
+		out = make(map[string]string)
+	}
+
+	for k, v := range oldMap {
+		out[k] = v
+	}
+
+	if newMap != nil && out == nil {
+		out = make(map[string]string)
+	}
+
+	for k, v := range newMap {
+		out[k] = v
+	}
+
+	return out
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the resources that are created on the `host` and `target` cluster have the creator and target namespace info as hash available (`terminal.dashboard.gardener.cloud/target-ns-hash`, `terminal.dashboard.gardener.cloud/created-by-hash`).

With this PR, resources that are created on the `host` and `target` cluster are annotated with `terminal.dashboard.gardener.cloud/created-by` and `terminal.dashboard.gardener.cloud/target-ns`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Resources created in `host` and `target` cluster are now annotated with the information of the creator of the terminal session and the target namespace (`terminal.dashboard.gardener.cloud/created-by` and `terminal.dashboard.gardener.cloud/target-ns`)
```
