### PR TITLE
Remove deprecated annotations

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -30,5 +30,4 @@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 cd "$SOURCE_PATH"
 
-# TODO remove exlusion "deprecated" checks in Makefile and .ci/check once deprecated fields GardenCreatedByDeprecated and TerminalLastHeartbeatDeprecated are removed
-golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"  --exclude ".*deprecated.*" --verbose --timeout 2m
+golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"  --verbose --timeout 2m

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ manifests: controller-gen
 
 # Run golangci-lint against code
 lint: $(GOPATH)/bin/golangci-lint
-# TODO remove exlusion "deprecated" checks in Makefile and .ci/check once deprecated fields GardenCreatedByDeprecated and TerminalLastHeartbeatDeprecated are removed
-	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*" --exclude ".*deprecated.*"
+	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"
 
 $(GOPATH)/bin/golangci-lint:
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -264,7 +264,7 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 		return nil, errors.New("target namespace not set")
 	}
 
-	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 && len(t.ObjectMeta.Annotations[GardenCreatedByDeprecated]) == 0 {
+	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 {
 		return nil, errors.New("createdBy annotation not set")
 	}
 
@@ -273,12 +273,7 @@ func (t *Terminal) NewLabelsSet() (*labels.Set, error) {
 		return nil, err
 	}
 
-	createdBy := t.ObjectMeta.Annotations[GardenCreatedByDeprecated]
-	if len(createdBy) == 0 {
-		createdBy = t.ObjectMeta.Annotations[GardenCreatedBy]
-	}
-
-	createdByHash, err := utils.ToFnvHash(createdBy)
+	createdByHash, err := utils.ToFnvHash(t.ObjectMeta.Annotations[GardenCreatedBy])
 	if err != nil {
 		return nil, err
 	}
@@ -296,16 +291,12 @@ func (t *Terminal) NewAnnotationsSet() (*utils.Set, error) {
 		return nil, errors.New("target namespace not set")
 	}
 
-	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 && len(t.ObjectMeta.Annotations[GardenCreatedByDeprecated]) == 0 {
+	if len(t.ObjectMeta.Annotations[GardenCreatedBy]) == 0 {
 		return nil, errors.New("createdBy annotation not set")
 	}
 
 	targetNamespace := *t.Spec.Target.Namespace
-
-	createdBy := t.ObjectMeta.Annotations[GardenCreatedByDeprecated]
-	if len(createdBy) == 0 {
-		createdBy = t.ObjectMeta.Annotations[GardenCreatedBy]
-	}
+	createdBy := t.ObjectMeta.Annotations[GardenCreatedBy]
 
 	return &utils.Set{
 		"terminal.dashboard.gardener.cloud/target-ns":  targetNamespace,
@@ -328,21 +319,9 @@ const (
 	// of the user that created the resource.
 	GardenCreatedBy = "gardener.cloud/created-by"
 
-	// GardenCreatedBy is the key for an annotation of a terminal resource whose value contains the username
-	// of the user that created the resource.
-	//
-	// Deprecated: Use `GardenCreatedBy` instead.
-	GardenCreatedByDeprecated = "garden.sapcloud.io/createdBy"
-
 	// TerminalLastHeartbeat is the key for an annotation of a terminal resource whose value contains the username
 	// of the user that created the resource.
 	TerminalLastHeartbeat = "dashboard.gardener.cloud/last-heartbeat-at"
-
-	// TerminalLastHeartbeat is the key for an annotation of a terminal resource whose value contains the username
-	// of the user that created the resource.
-	//
-	// Deprecated: Use `TerminalLastHeartbeat` instead.
-	TerminalLastHeartbeatDeprecated = "dashboard.gardener.cloud/lastHeartbeatAt"
 
 	// ShootOperation is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.
 	TerminalOperation = "dashboard.gardener.cloud/operation"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
 
 images:
 - name: controller
-  newName: psutter/dashboard-terminal
-  newTag: go1.14
+  newName: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
+  newTag: latest
 
 configMapGenerator:
 - files:

--- a/controllers/terminalheartbeat_controller.go
+++ b/controllers/terminalheartbeat_controller.go
@@ -73,11 +73,7 @@ func (r *TerminalHeartbeatReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, nil
 	}
 
-	lastHeartbeat := t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeatDeprecated]
-	if len(lastHeartbeat) == 0 {
-		lastHeartbeat = t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeat]
-	}
-
+	lastHeartbeat := t.ObjectMeta.Annotations[extensionsv1alpha1.TerminalLastHeartbeat]
 	if len(lastHeartbeat) == 0 {
 		// if there is no heartbeat set, delete right away
 		return ctrl.Result{}, r.deleteTerminal(ctx, t)

--- a/webhooks/mutating/terminal_create_update_handler.go
+++ b/webhooks/mutating/terminal_create_update_handler.go
@@ -50,7 +50,6 @@ func (h *TerminalMutator) mutatingTerminalFn(ctx context.Context, t *v1alpha1.Te
 
 	if admissionReq.Operation == v1beta1.Create {
 		t.ObjectMeta.Annotations[v1alpha1.GardenCreatedBy] = admissionReq.UserInfo.Username
-		t.ObjectMeta.Annotations[v1alpha1.GardenCreatedByDeprecated] = admissionReq.UserInfo.Username
 
 		uuidString := uuid.NewV4().String()
 
@@ -67,13 +66,11 @@ func (h *TerminalMutator) mutatingTerminalFn(ctx context.Context, t *v1alpha1.Te
 		h.mutateNamespaceIfTemporary(t, terminalIdentifier)
 
 		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] = time.Now().UTC().Format(time.RFC3339)
-		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	if t.ObjectMeta.Annotations[v1alpha1.TerminalOperation] == v1alpha1.TerminalOperationKeepalive {
 		delete(t.ObjectMeta.Annotations, v1alpha1.TerminalOperation)
 		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] = time.Now().UTC().Format(time.RFC3339)
-		t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	return nil

--- a/webhooks/validating/terminal_create_update_handler.go
+++ b/webhooks/validating/terminal_create_update_handler.go
@@ -62,24 +62,12 @@ func (h *TerminalValidator) validatingTerminalFn(ctx context.Context, t *v1alpha
 			return false, err.Error(), nil
 		}
 
-		createdByFldPath = field.NewPath("metadata", "annotations", v1alpha1.GardenCreatedByDeprecated)
-		if err := validateImmutableField(t.ObjectMeta.Annotations[v1alpha1.GardenCreatedByDeprecated], oldT.ObjectMeta.Annotations[v1alpha1.GardenCreatedByDeprecated], createdByFldPath); err != nil {
-			return false, err.Error(), nil
-		}
-
 		// only same user is allowed to keep terminal session alive
-		userFromAnnotations := t.ObjectMeta.Annotations[v1alpha1.GardenCreatedByDeprecated]
-		if len(userFromAnnotations) == 0 {
-			userFromAnnotations = t.ObjectMeta.Annotations[v1alpha1.GardenCreatedBy]
-		}
-
+		userFromAnnotations := t.ObjectMeta.Annotations[v1alpha1.GardenCreatedBy]
 		changedBySameUser := userFromAnnotations == admissionReq.UserInfo.Username
+
 		if t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] != oldT.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeat] && !changedBySameUser {
 			return false, field.Forbidden(field.NewPath("metadata", "annotations", v1alpha1.TerminalLastHeartbeat), "you are not allowed to change this field").Error(), nil
-		}
-
-		if t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] != oldT.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated] && !changedBySameUser {
-			return false, field.Forbidden(field.NewPath("metadata", "annotations", v1alpha1.TerminalLastHeartbeatDeprecated), "you are not allowed to change this field").Error(), nil
 		}
 	}
 
@@ -92,18 +80,6 @@ func (h *TerminalValidator) validatingTerminalFn(ctx context.Context, t *v1alpha
 
 		if lastHeartBeatParsed.After(time.Now().UTC()) {
 			return false, field.Forbidden(field.NewPath("metadata", "annotations", v1alpha1.TerminalLastHeartbeat), "time must not be in the future").Error(), nil
-		}
-	}
-
-	lastHeartbeat = t.ObjectMeta.Annotations[v1alpha1.TerminalLastHeartbeatDeprecated]
-	if len(lastHeartbeat) > 0 {
-		lastHeartBeatParsed, err := time.Parse(time.RFC3339, lastHeartbeat)
-		if err != nil {
-			return false, field.Invalid(field.NewPath("metadata", "annotations", v1alpha1.TerminalLastHeartbeatDeprecated), lastHeartbeat, "failed to parse time").Error(), nil
-		}
-
-		if lastHeartBeatParsed.After(time.Now().UTC()) {
-			return false, field.Forbidden(field.NewPath("metadata", "annotations", v1alpha1.TerminalLastHeartbeatDeprecated), "time must not be in the future").Error(), nil
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated annotations

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Make sure to update `terminal-controller-manager` from `v0.8.0`. Otherwise current terminal sessions can't be annotated anymore with `dashboard.gardener.cloud/operation=keepalive` and will be terminated when reaching time to live.
```
