### PR TITLE
Add script to setup local dev certs

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -17,7 +17,7 @@ terminal-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/terminal-controller-manager'
     steps:
       check:
-        image: 'golang:1.15.1'
+        image: 'golang:1.15.3'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15.1 as builder
+FROM golang:1.15.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ There are two options to deploy the `terminal-controller-manager` into your clus
 
 ## Single-Cluster Setup with `Kind`
 
+To setup local development certificates under the /tmp directory needed by the controller execute:
+
+```bash
+./hack/setup-local-dev-certs
+```
+
 To deploy the `terminal-controller-manager` into a single-cluster execute:
 
 ```bash

--- a/hack/setup-local-dev-certs
+++ b/hack/setup-local-dev-certs
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd "${0%/*}"
+echo "Generating certificates.."
+./gen-certs
+
+if [ -z "${CERTS_DIR}" ]; then
+    export CERTS_DIR=/tmp/k8s-webhook-server/serving-certs
+fi
+
+echo "Creating temporary directory for serving certs under $CERTS_DIR"
+mkdir -p $CERTS_DIR
+
+echo "Copying certificates to $CERTS_DIR"
+cp ../config/secret/tls/terminal-controller-manager-tls.pem $CERTS_DIR/tls.crt
+cp ../config/secret/tls/terminal-controller-manager-tls-key.pem $CERTS_DIR/tls.key


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains two changes:
- Add script to setup local dev certs
- Update golang to 1.15.3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
