### PR TITLE
Update kube-rbac-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 
 # nonroot user https://github.com/GoogleContainerTools/distroless/blob/18b2d2c5ebfa58fe3e0e4ee3ffe0e2651ec0f7f6/base/base.bzl#L8
-USER 65532
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= eu.gcr.io/gardener-project/gardener/terminal-controller-manager:latest
 
 # Kube RBAC Proxy image to use
-IMG_RBAC_PROXY ?= gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+IMG_RBAC_PROXY ?= quay.io/brancz/kube-rbac-proxy:v0.8.0
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
@@ -49,7 +49,7 @@ bootstrap-dev-project: bootstrap-dev
 
 apply-image: manifests
 	cd config/manager && kustomize edit set image "controller=${IMG}"
-	cd config/default && kustomize edit set image "gcr.io/kubebuilder/kube-rbac-proxy=${IMG_RBAC_PROXY}"
+	cd config/default && kustomize edit set image "quay.io/brancz/kube-rbac-proxy=${IMG_RBAC_PROXY}"
 
 # Multi-cluster use case: Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy-rt: apply-image

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,6 +23,6 @@ patchesStrategicMerge:
 - manager_webhook_patch.yaml
 
 images:
-- name: gcr.io/kubebuilder/kube-rbac-proxy
-  newName: gcr.io/kubebuilder/kube-rbac-proxy
-  newTag: v0.5.0
+- name: quay.io/brancz/kube-rbac-proxy
+  newName: quay.io/brancz/kube-rbac-proxy
+  newTag: v0.8.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -19,6 +19,16 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 65532
       containers:
       - command:
         - /manager
@@ -40,6 +42,7 @@ spec:
             memory: 100Mi
         securityContext:
           runAsNonRoot: true
+          allowPrivilegeEscalation: false
         volumeMounts:
           - mountPath: /etc/terminal-controller-manager
             name: manager-config


### PR DESCRIPTION
**What this PR does / why we need it**:
- With this PR the `kube-rbac-proxy` will be updated to  to v0.8.0 release

`kube-rbac-proxy` container:
- Resource limits and requests are set
- Added the `securityContext` ` runAsNonRoot: true` and `allowPrivilegeEscalation: false` for the which was possible with the `kube-rbac-proxy` v0.7.0 release

`terminal-controller-manager` container:
- set `allowPrivilegeEscalation: false`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```other operator
Updated `kube-rbac-proxy` to v0.8.0
```
