### PR TITLE
Fetch terminal before updating status

### DIFF
--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -576,9 +576,7 @@ func (r *TerminalReconciler) createOrUpdateAttachPodSecret(ctx context.Context, 
 		return err
 	}
 
-	t.Status.AttachServiceAccountName = attachPodServiceAccount.Name
-
-	err = r.Status().Update(ctx, t)
+	err = r.updateTerminalStatusAttachServiceAccountName(ctx, t, attachPodServiceAccount.Name)
 	if err != nil {
 		return err
 	}
@@ -621,6 +619,34 @@ func (r *TerminalReconciler) createOrUpdateAttachPodSecret(ctx context.Context, 
 	}
 
 	return nil
+}
+
+func (r *TerminalReconciler) updateTerminalStatusAttachServiceAccountName(ctx context.Context, t *extensionsv1alpha1.Terminal, attachServiceAccountName string) error {
+	terminal := &extensionsv1alpha1.Terminal{}
+
+	// make sure to fetch the latest version of the terminal resource before updating it's status
+	err := r.Get(ctx, client.ObjectKey{Name: t.Name, Namespace: t.Namespace}, terminal)
+	if err != nil {
+		return err
+	}
+
+	terminal.Status.AttachServiceAccountName = attachServiceAccountName
+
+	return r.Status().Update(ctx, terminal)
+}
+
+func (r *TerminalReconciler) updateTerminalStatusPodName(ctx context.Context, t *extensionsv1alpha1.Terminal, podName string) error {
+	terminal := &extensionsv1alpha1.Terminal{}
+
+	// make sure to fetch the latest version of the terminal resource before updating it's status
+	err := r.Get(ctx, client.ObjectKey{Name: t.Name, Namespace: t.Namespace}, terminal)
+	if err != nil {
+		return err
+	}
+
+	terminal.Status.PodName = podName
+
+	return r.Status().Update(ctx, terminal)
 }
 
 func createOrUpdateAttachRole(ctx context.Context, hostClientSet *ClientSet, namespace string, name string, rules []rbacv1.PolicyRule) (*rbacv1.Role, error) {
@@ -1065,9 +1091,7 @@ func (r *TerminalReconciler) createOrUpdateTerminalPod(ctx context.Context, cs *
 		kubeconfigReadOnlyVolumeName  = "kubeconfig"
 	)
 
-	t.Status.PodName = pod.Name
-
-	err := r.Status().Update(ctx, t)
+	err := r.updateTerminalStatusPodName(ctx, t, pod.Name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fetching the terminal before updating it's status should prevent `the object has been modified; please apply your changes to the latest version and try again` in case the resource was updated in the meantime

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Terminal resource is fetched again before updating its status. This should reduce the likelihood of getting the error `the object has been modified; please apply your changes to the latest version and try again` when updating the status.
```
