### PR TITLE
Adds additional toleration options to terminal pod

### DIFF
--- a/controllers/terminalheartbeat_controller_test.go
+++ b/controllers/terminalheartbeat_controller_test.go
@@ -125,7 +125,9 @@ var _ = Describe("Terminal Controller", func() {
 	Context("terminal lifecycle", func() {
 		Context("expired lifetime", func() {
 			BeforeEach(func() {
-				cmConfig.Controllers.TerminalHeartbeat.TimeToLive = v1alpha1.Duration{Duration: time.Duration(1) * time.Second}
+				configWithNewTTL := test.DefaultConfiguration()
+				configWithNewTTL.Controllers.TerminalHeartbeat.TimeToLive = v1alpha1.Duration{Duration: time.Duration(1) * time.Second}
+				terminalHeartbeatReconciler.injectConfig(configWithNewTTL)
 			})
 			It("Should delete terminal", func() {
 				Expect(terminalCreationError).Should(Not(HaveOccurred()))


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the following tolerations when a nodeSelector is specified for the pod in the `terminal` custom resource:
```
- operator: Exists
  effect: NoExecute
- key: CriticalAddonsOnly
  operator: Exists
```
This is so that terminal pods can be started on user nodes which have the `NoExecute` effect or the `CriticalAddonsOnly` key.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Tolerations with `NoExecute` effect and `CriticalAddonsOnly` key will be added to the terminal pod when `host.pod.nodeSelector` is specified in the `Terminal` resource.
```
