### PR TITLE
Bump kube-rbac-proxy to v0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 IMG ?= eu.gcr.io/gardener-project/gardener/terminal-controller-manager
 
 # Kube RBAC Proxy image to use
-IMG_RBAC_PROXY ?= quay.io/brancz/kube-rbac-proxy:v0.8.0
+IMG_RBAC_PROXY ?= quay.io/brancz/kube-rbac-proxy:v0.12.0
 
 REPO_ROOT           := $(shell git rev-parse --show-toplevel)
 VERSION             := $(shell cat "$(REPO_ROOT)/VERSION")

--- a/Makefile
+++ b/Makefile
@@ -113,15 +113,15 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy-rt
 deploy-rt: apply-image kustomize ## Multi-cluster use case: Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	kustomize build config/overlay/multi-cluster/runtime | kubectl apply -f -
+	$(KUSTOMIZE) build config/overlay/multi-cluster/runtime | kubectl apply -f -
 
 .PHONY: deploy-virtual
 deploy-virtual: apply-image kustomize ## Multi-cluster use case: Deploy crd, admission configurations etc. in the configured Kubernetes cluster
-	kustomize build config/overlay/multi-cluster/virtual-garden | kubectl apply -f -
+	$(KUSTOMIZE) build config/overlay/multi-cluster/virtual-garden | kubectl apply -f -
 
 .PHONY: deploy-singlecluster
 deploy-singlecluster: apply-image ## Single-cluster use case: Deploy crd, admission configurations, controller etc. in the configured Kubernetes cluster
-	kustomize build config/overlay/single-cluster | kubectl apply -f -
+	$(KUSTOMIZE) build config/overlay/single-cluster | kubectl apply -f -
 
 .PHONY: apply-image
 apply-image: manifests kustomize ## Apply terminal controller and kube-rbac-proxy images according to the variables IMG and IMG_RBAC_PROXY

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
 - name: quay.io/brancz/kube-rbac-proxy
   newName: quay.io/brancz/kube-rbac-proxy
-  newTag: v0.8.0
+  newTag: v0.12.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP
@@ -28,11 +28,11 @@ spec:
           allowPrivilegeEscalation: false
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 128Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/rbac-rt/auth_proxy_service.yaml
+++ b/config/rbac-rt/auth_proxy_service.yaml
@@ -19,6 +19,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kube-rbac-proxy to v0.12.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
