### PR TITLE
Bump kube-rbac-proxy to v0.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 IMG ?= eu.gcr.io/gardener-project/gardener/terminal-controller-manager
 
 # Kube RBAC Proxy image to use
-IMG_RBAC_PROXY ?= quay.io/brancz/kube-rbac-proxy:v0.12.0
+IMG_RBAC_PROXY ?= quay.io/brancz/kube-rbac-proxy:v0.13.0
 
 REPO_ROOT           := $(shell git rev-parse --show-toplevel)
 VERSION             := $(shell cat "$(REPO_ROOT)/VERSION")

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
 - name: quay.io/brancz/kube-rbac-proxy
   newName: quay.io/brancz/kube-rbac-proxy
-  newTag: v0.12.0
+  newTag: v0.13.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kube-rbac-proxy to v0.13.0

**Which issue(s) this PR fixes**:
Fixes #68 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated `kube-rbac-proxy` to `v0.13.0`
```
