### PR TITLE
Change mountPath to /host

### DIFF
--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -1203,7 +1203,7 @@ func (r *TerminalReconciler) createOrUpdateTerminalPod(ctx context.Context, cs *
 				rootVolumeName := "root-volume"
 				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 					Name:      rootVolumeName,
-					MountPath: "/hostroot",
+					MountPath: "/host",
 				})
 				pod.Spec.Volumes = []corev1.Volume{
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:
As agreed in https://github.com/gardener/ops-toolbelt/pull/82#discussion_r925724996 we are aligning the mountPath of the hosts root fs to `/host` (https://github.com/gardener/ops-toolbelt/blob/master/hacks/ops-pod#L177)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The volume mount path for the hosts root filesystem changed from `/hostroot` to `/host`
```
