### PR TITLE
Support kubeconfigs using gke auth plugin

### DIFF
--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -262,7 +262,8 @@ func NewClientSetFromSecret(ctx context.Context, config *rest.Config, secret *co
 			return nil, fmt.Errorf("no auth info found with name %s", context.AuthInfo)
 		}
 
-		if authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "gcp" {
+		if (authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "gcp") ||
+			(authInfo.Exec != nil && authInfo.Exec.Command == "gke-gcloud-auth-plugin") {
 			gsaKey, ok := secret.Data[DataKeyServiceaccountJSON]
 			if !ok {
 				return nil, fmt.Errorf("%q required in secret for gcp authentication provider", DataKeyServiceaccountJSON)


### PR DESCRIPTION
**What this PR does / why we need it**:
Support kubeconfigs using gke auth plugin

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added support for `gke-gcloud-auth-plugin` in kubeconfig secrets. The secret needs to have the `serviceaccount.json` data key in addition.
```
