### PR TITLE
Keep golangci-lint version in sync

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0
         with:
-          version: v1.50
+          version: v1.51.2
           args: --verbose --timeout 5m


### PR DESCRIPTION
**What this PR does / why we need it**:
Keep golangci-lint version in github action in sync with hack script that is used for the build pipeline or for local lint checks https://github.com/gardener/terminal-controller-manager/blob/master/hack/golangci-lint.sh#L22

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
