### PR TITLE
Adds toleration to allow scheduling terminal pod on any node

### DIFF
--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -1049,29 +1049,11 @@ func (r *TerminalReconciler) createOrUpdateTerminalPod(ctx context.Context, cs *
 				pod.Spec.Tolerations = []corev1.Toleration{}
 			}
 
-			criticalAddonsKey := "CriticalAddonsOnly"
-			if !tolerationExists(pod.Spec.Tolerations, matchByKey(criticalAddonsKey)) {
-				pod.Spec.Tolerations = append(pod.Spec.Tolerations,
-					corev1.Toleration{
-						Key:      criticalAddonsKey,
-						Operator: corev1.TolerationOpExists,
-					})
-			}
-
-			noExecuteToleration := corev1.Toleration{
+			existsToleration := corev1.Toleration{
 				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoExecute,
 			}
-			if !tolerationExists(pod.Spec.Tolerations, match(noExecuteToleration)) {
-				pod.Spec.Tolerations = append(pod.Spec.Tolerations, noExecuteToleration)
-			}
-
-			noScheduleToleration := corev1.Toleration{
-				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoSchedule,
-			}
-			if !tolerationExists(pod.Spec.Tolerations, match(noScheduleToleration)) {
-				pod.Spec.Tolerations = append(pod.Spec.Tolerations, noScheduleToleration)
+			if !tolerationExists(pod.Spec.Tolerations, match(existsToleration)) {
+				pod.Spec.Tolerations = append(pod.Spec.Tolerations, existsToleration)
 			}
 		}
 

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -1048,16 +1048,8 @@ func (r *TerminalReconciler) createOrUpdateTerminalPod(ctx context.Context, cs *
 			if len(pod.Spec.Tolerations) == 0 {
 				pod.Spec.Tolerations = []corev1.Toleration{}
 			}
-			masterNodeKey := "node-role.kubernetes.io/master"
+
 			criticalAddonsKey := "CriticalAddonsOnly"
-			if !tolerationExists(pod.Spec.Tolerations, matchByKey(masterNodeKey)) {
-				pod.Spec.Tolerations = append(pod.Spec.Tolerations,
-					corev1.Toleration{
-						Key:      masterNodeKey,
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoSchedule,
-					})
-			}
 			if !tolerationExists(pod.Spec.Tolerations, matchByKey(criticalAddonsKey)) {
 				pod.Spec.Tolerations = append(pod.Spec.Tolerations,
 					corev1.Toleration{
@@ -1072,6 +1064,14 @@ func (r *TerminalReconciler) createOrUpdateTerminalPod(ctx context.Context, cs *
 			}
 			if !tolerationExists(pod.Spec.Tolerations, match(noExecuteToleration)) {
 				pod.Spec.Tolerations = append(pod.Spec.Tolerations, noExecuteToleration)
+			}
+
+			noScheduleToleration := corev1.Toleration{
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}
+			if !tolerationExists(pod.Spec.Tolerations, match(noScheduleToleration)) {
+				pod.Spec.Tolerations = append(pod.Spec.Tolerations, noScheduleToleration)
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

add toleration to everything with `Exists` operator, as terminal pod cannot be scheduled to node with custom taints like `nvidia.com/gpu: present`.

**Which issue(s) this PR fixes**:
Fixes #162 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds toleration to allow scheduling terminal pod on any node by default.
```
