### PR TITLE
Adapt `NetworkPolicy`s

### DIFF
--- a/charts/terminal/charts/runtime/templates/admission-controller/service.yaml
+++ b/charts/terminal/charts/runtime/templates/admission-controller/service.yaml
@@ -3,6 +3,11 @@ kind: Service
 metadata:
   name: terminal-admission-controller
   namespace: {{ .Release.Namespace }}
+  annotations:
+    networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":9443}]'
+    {{- if ne .Release.Namespace "garden" }}
+    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
+    {{- end }}
   labels:
     app.kubernetes.io/name: terminal
     app.kubernetes.io/component: admission-controller

--- a/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
@@ -36,6 +36,15 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        {{- if eq .Release.Namespace "garden" }}
+        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
+        {{- else }}
+        networking.resources.gardener.cloud/to-garden-virtual-garden-kube-apiserver-tcp-443: allowed
+        {{- end }}
         {{- if .Values.global.controller.podLabels }}
         {{- toYaml .Values.global.controller.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/terminal/charts/runtime/templates/controller-manager/namespace.yaml
+++ b/charts/terminal/charts/runtime/templates/controller-manager/namespace.yaml
@@ -8,4 +8,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- if ne .Release.Namespace "garden" }}
+    networking.gardener.cloud/access-target-apiserver: allowed
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security networking
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the `NetworkPolicy`s as following:

- egress traffic to DNS, the runtime cluster, and to the virtual garden kube-apiserver is allowed
- egress to public and private networks is allowed (to reach API servers of seeds and shoots)
- ingress from the virtual garden kube-apiserver is allowed

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Helm chart are now adapted such that they work well in garden cluster with enabled `NetworkPolicy` protection (default since `gardener/gardener@v1.71` when garden cluster is managed by `gardener-operator`).
```
