### PR TITLE
Bump kube-rbac-proxy to 0.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ IMG_MANAGER_TAG        ?= $(VERSION)-$(shell git rev-parse HEAD)
 
 # Docker image repository and tag for Kube RBAC Proxy tool
 IMG_RBAC_PROXY_REPOSITORY ?= quay.io/brancz/kube-rbac-proxy
-IMG_RBAC_PROXY_TAG        ?= v0.14.0
+IMG_RBAC_PROXY_TAG        ?= v0.14.1
 
 # Chart variables
 CREATE_NAMESPACE ?= true

--- a/charts/terminal/values.yaml
+++ b/charts/terminal/values.yaml
@@ -78,7 +78,7 @@ global:
       logVerbosity: 0
       image:
         repository: quay.io/brancz/kube-rbac-proxy
-        tag: v0.14.0
+        tag: v0.14.1
         pullPolicy: IfNotPresent
       serviceAccountTokenVolumeProjection:
         enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kube-rbac-proxy to 0.14.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
