### PR TITLE
Add namespace alias for `NetworkPolicy`

### DIFF
--- a/charts/terminal/charts/runtime/templates/admission-controller/service.yaml
+++ b/charts/terminal/charts/runtime/templates/admission-controller/service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":9443}]'
     {{- if ne .Release.Namespace "garden" }}
+    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: extensions
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
     {{- end }}
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts the `NetworkPolicy` configuration to https://github.com/gardener/gardener/pull/8076, i.e. it introduces the `extensions` alias for the namespace. This way, the `kube-apiserver` can actually reach the webhook server in case the `terminal-controller-manager` was deployed in a namespace different than `garden`.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/terminal-controller-manager/pull/172

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented the webhook handler from being reached by `kube-apiserver`s in case the `terminal-controller-manager` was deployed in a namespace different than `garden`.
```
