### PR TITLE
Add support for projected volume kubeconfig

### DIFF
--- a/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
@@ -76,6 +76,9 @@ spec:
         {{- if .Values.global.controller.kubeRBACProxy.kubeconfig }}
         - --kubeconfig=/etc/kube-rbac-proxy/secrets/kubeconfig/kubeconfig
         {{- end }}
+        {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
+        - --kubeconfig={{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath }}/kubeconfig
+        {{- end }}
         {{- if .Values.global.controller.kubeRBACProxy.livenessProbe.enabled }}
         {{- /*
         The port to securely serve proxy-specific endpoints (such as '/healthz'). Uses the host from the '--secure-listen-address'.
@@ -127,6 +130,11 @@ spec:
           mountPath: /var/run/secrets/projected/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
+        - name: kubeconfig-kube-rbac-proxy
+          mountPath: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath }}
+          readOnly: true
+        {{- end }}
       - name: manager
         image: "{{ include "utils-templates.image" .Values.global.controller.manager.image }}"
         imagePullPolicy: {{ .Values.global.controller.manager.image.pullPolicy }}
@@ -143,6 +151,10 @@ spec:
         {{- if .Values.global.controller.manager.kubeconfig }}
         - name: KUBECONFIG
           value: /etc/terminal-controller-manager/secrets/kubeconfig/kubeconfig
+        {{- end }}
+        {{- if .Values.global.controller.manager.projectedKubeconfig }}
+        - name: KUBECONFIG
+          value: {{ required ".Values.global.controller.manager.projectedKubeconfig.baseMountPath is required" .Values.global.controller.manager.projectedKubeconfig.baseMountPath }}/kubeconfig
         {{- end }}
         {{- if .Values.global.controller.manager.livenessProbe.enabled }}
         livenessProbe:
@@ -182,6 +194,11 @@ spec:
           mountPath: /var/run/secrets/projected/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if .Values.global.controller.manager.projectedKubeconfig }}
+        - name: kubeconfig-manager
+          mountPath: {{ required ".Values.global.controller.manager.projectedKubeconfig.baseMountPath is required" .Values.global.controller.manager.projectedKubeconfig.baseMountPath }}
+          readOnly: true
+        {{- end }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: terminal-admission-controller-cert
           readOnly: true
@@ -213,6 +230,23 @@ spec:
               audience: {{ .Values.global.controller.manager.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
       {{- end }}
+      {{- if .Values.global.controller.manager.projectedKubeconfig }}
+      - name: kubeconfig-manager
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.global.controller.manager.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.global.controller.manager.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.global.controller.manager.projectedKubeconfig.tokenSecretName is required" .Values.global.controller.manager.projectedKubeconfig.tokenSecretName }}
+              optional: false
+      {{- end }}
       {{- if .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.enabled }}
       - name: service-account-token-kube-rbac-proxy
         projected:
@@ -223,6 +257,23 @@ spec:
               {{- if .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.audience }}
               audience: {{ .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
+      {{- end }}
+      {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
+      - name: kubeconfig-kube-rbac-proxy
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.tokenSecretName is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.tokenSecretName }}
+              optional: false
       {{- end }}
       {{- if .Values.global.admission.config.server.webhooks.tlsSecretName }}
       - name: terminal-admission-controller-cert

--- a/charts/terminal/values.yaml
+++ b/charts/terminal/values.yaml
@@ -42,6 +42,14 @@ global:
         enabled: true
         expirationSeconds: 3600
         audience: ''
+    # If configured, the terminal-controller-manager deployment uses a projected volume which presents the kubeconfig to the garden cluster.
+    # projectedKubeconfig:
+    #   # Path the projected volume is mounted to. This is typically also the base path in the generic kubeconfig to refer to the token file.
+    #   baseMountPath: /var/run/secrets/gardener.cloud
+    #   # Secret which contains a generic kubeconfig and a reference to a token file.
+    #   genericKubeconfigSecretName: generic-token-kubeconfig
+    #   # Secret which contains the access token, required by the generic kubeconfig.
+    #   tokenSecretName: access-terminal-manager
       config:
         server:
           healthProbes:
@@ -84,6 +92,14 @@ global:
         enabled: true
         expirationSeconds: 3600
         audience: ''
+    # If configured, the terminal-controller-manager deployment uses a projected volume which presents the kubeconfig to the garden cluster.
+    # projectedKubeconfig:
+    #   # Path the projected volume is mounted to. This is typically also the base path in the generic kubeconfig to refer to the token file.
+    #   baseMountPath: /var/run/secrets/gardener.cloud
+    #   # Secret which contains a generic kubeconfig and a reference to a token file.
+    #   genericKubeconfigSecretName: generic-token-kubeconfig
+    #   # Secret which contains the access token, required by the generic kubeconfig.
+    #   tokenSecretName: access-terminal-kube-rbac-proxy
       config:
         server:
           proxy:


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds the option to configure a kubeconfig projected volume for the terminal deployment. It is for example needed, if operators generate their kubeconfigs for the virtual garden cluster via the [TokenRequestor](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokeninvalidator-controller).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `terminal` chart allows to optionally configure a projected volume based kubeconfig.
```