### PR TITLE
Revert project volume for `kube-rbac-proxy`

### DIFF
--- a/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
@@ -76,9 +76,6 @@ spec:
         {{- if .Values.global.controller.kubeRBACProxy.kubeconfig }}
         - --kubeconfig=/etc/kube-rbac-proxy/secrets/kubeconfig/kubeconfig
         {{- end }}
-        {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
-        - --kubeconfig={{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath }}/kubeconfig
-        {{- end }}
         {{- if .Values.global.controller.kubeRBACProxy.livenessProbe.enabled }}
         {{- /*
         The port to securely serve proxy-specific endpoints (such as '/healthz'). Uses the host from the '--secure-listen-address'.
@@ -128,11 +125,6 @@ spec:
         {{- if .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.enabled }}
         - name: service-account-token-kube-rbac-proxy
           mountPath: /var/run/secrets/projected/serviceaccount
-          readOnly: true
-        {{- end }}
-        {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
-        - name: kubeconfig-kube-rbac-proxy
-          mountPath: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.baseMountPath }}
           readOnly: true
         {{- end }}
       - name: manager
@@ -257,23 +249,6 @@ spec:
               {{- if .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.audience }}
               audience: {{ .Values.global.controller.kubeRBACProxy.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
-      {{- end }}
-      {{- if .Values.global.controller.kubeRBACProxy.projectedKubeconfig }}
-      - name: kubeconfig-kube-rbac-proxy
-        projected:
-          sources:
-          - secret:
-              items:
-              - key: kubeconfig
-                path: kubeconfig
-              name: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.genericKubeconfigSecretName }}
-              optional: false
-          - secret:
-              items:
-              - key: token
-                path: token
-              name: {{ required ".Values.global.controller.kubeRBACProxy.projectedKubeconfig.tokenSecretName is required" .Values.global.controller.kubeRBACProxy.projectedKubeconfig.tokenSecretName }}
-              optional: false
       {{- end }}
       {{- if .Values.global.admission.config.server.webhooks.tlsSecretName }}
       - name: terminal-admission-controller-cert

--- a/charts/terminal/values.yaml
+++ b/charts/terminal/values.yaml
@@ -92,14 +92,6 @@ global:
         enabled: true
         expirationSeconds: 3600
         audience: ''
-    # If configured, the terminal-controller-manager deployment uses a projected volume which presents the kubeconfig to the garden cluster.
-    # projectedKubeconfig:
-    #   # Path the projected volume is mounted to. This is typically also the base path in the generic kubeconfig to refer to the token file.
-    #   baseMountPath: /var/run/secrets/gardener.cloud
-    #   # Secret which contains a generic kubeconfig and a reference to a token file.
-    #   genericKubeconfigSecretName: generic-token-kubeconfig
-    #   # Secret which contains the access token, required by the generic kubeconfig.
-    #   tokenSecretName: access-terminal-kube-rbac-proxy
       config:
         server:
           proxy:


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts changes for `kube-rbac-proxy` introduced with #202. This component doesn't require a kubeconfig for the `virtual-garden` cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
