### PR TITLE
Fix leader election config

### DIFF
--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -329,7 +329,8 @@ type ControllerManagerConfiguration struct {
 	HonourCleanupProjectMembership *bool `yaml:"honourCleanupProjectMembership,omitempty"`
 
 	// LeaderElection defines the configuration of leader election client.
-	LeaderElection *componentbaseconfig.LeaderElectionConfiguration
+	// +optional
+	LeaderElection *componentbaseconfig.LeaderElectionConfiguration `yaml:"leaderElection,omitempty"`
 }
 
 // ServerConfiguration contains details for the HTTP(S) servers.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the `ControllerManagerConfiguration` API which missed a struct tag to configure leader election for the controller.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that cause leader election configuration being ignored in the `ControllerManagerConfiguration` API.
```
