### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 terminal-controller-manager:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -13,7 +11,6 @@ terminal-controller-manager:
             inputs:
               repos:
                 source: ~ # default
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/terminal-controller-manager'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,13 +5,15 @@ terminal-controller-manager:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
           terminal:
             inputs:
               repos:
                 source: ~ # default
-            image: 'eu.gcr.io/gardener-project/gardener/terminal-controller-manager'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/terminal-controller-manager'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
               value:
@@ -29,7 +31,9 @@ terminal-controller-manager:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -38,6 +42,8 @@ terminal-controller-manager:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
         slack:
@@ -46,8 +52,8 @@ terminal-controller-manager:
             internal_scp_workspace:
               channel_name: 'C017DNNNENQ' # garden-dashboard channel
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           dockerimages:
             terminal:
               tag_as_latest: true
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 VERSION        := $(shell cat "$(REPO_ROOT)/VERSION")
 
 # Docker image repository and tag for terminal-controller-manager
-IMG_MANAGER_REPOSITORY ?= eu.gcr.io/gardener-project/gardener/terminal-controller-manager
+IMG_MANAGER_REPOSITORY ?= europe-docker.pkg.dev/gardener-project/public/gardener/terminal-controller-manager
 IMG_MANAGER_TAG        ?= $(VERSION)-$(shell git rev-parse HEAD)
 
 # Docker image repository and tag for Kube RBAC Proxy tool

--- a/charts/terminal/values.yaml
+++ b/charts/terminal/values.yaml
@@ -35,7 +35,7 @@ global:
     # manager defines configuration values for the manager container
     manager:
       image:
-        repository: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
+        repository: europe-docker.pkg.dev/gardener-project/public/gardener/terminal-controller-manager
         tag: latest
         pullPolicy: IfNotPresent
       serviceAccountTokenVolumeProjection:

--- a/example/terminal-cp.yaml
+++ b/example/terminal-cp.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.gardener.cloud/to-public-networks: allowed
       container:
-        image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.21.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
         args:
           - watch
           - kubectl

--- a/example/terminal-cp.yaml
+++ b/example/terminal-cp.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.gardener.cloud/to-public-networks: allowed
       container:
-        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.26.0
         args:
           - watch
           - kubectl

--- a/example/terminal-garden.yaml
+++ b/example/terminal-garden.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.gardener.cloud/to-public-networks: allowed
       container:
-        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.26.0
   target:
     credentials:
       serviceAccountRef:

--- a/example/terminal-garden.yaml
+++ b/example/terminal-garden.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.gardener.cloud/to-public-networks: allowed
       container:
-        image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.21.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
   target:
     credentials:
       serviceAccountRef:

--- a/example/terminal-shoot.yaml
+++ b/example/terminal-shoot.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-all-shoot-apiservers: allowed
       container:
-        image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.21.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
   target:
     credentials:
       shootRef:

--- a/example/terminal-shoot.yaml
+++ b/example/terminal-shoot.yaml
@@ -22,7 +22,7 @@ spec:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-all-shoot-apiservers: allowed
       container:
-        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.25.0
+        image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.26.0
   target:
     credentials:
       shootRef:


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
