### PR TITLE
Github action to update golang version

### DIFF
--- a/.github/workflows/bump-golang.yaml
+++ b/.github/workflows/bump-golang.yaml
@@ -1,0 +1,41 @@
+name: bump golang
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  bump-golang:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.title, 'Bump golang from')
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # pin@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Update Golang version in pipeline_definition
+        run: |
+          NEW_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          sed -i "s/golang:[0-9]*\.[0-9]*\.[0-9]*/golang:$NEW_VERSION/g" .ci/pipeline_definitions
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5.0.0
+        with:
+          go-version: ${{ steps.dependabot-metadata.outputs.new-version }}
+      - name: Update Golang version in go.mod
+        run: |
+          FULL_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          MAJOR_MINOR_VERSION=$(echo $FULL_VERSION | cut -d. -f1,2)
+          go mod edit -go=$MAJOR_MINOR_VERSION
+          go mod tidy
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          if git diff --quiet; then
+            echo "Skip - No changes detected"
+            exit 0
+          fi
+          git commit -am "[dependabot-skip] Update Golang version to ${{ steps.dependabot-metadata.outputs.new-version }}"
+          git push

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,10 +13,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5.0.0
         with:
-          go-version: 1.22.0
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # pin@v4.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR runs when dependabot creates a PR to update the golang version for the package-ecosystem `docker` ([ref](https://github.com/gardener/terminal-controller-manager/blob/b3c13c87756da2abae154cdc56f87ecd60dbdd5e/.github/dependabot.yml#L29-L32)). Unfortunately, not all places where the golang version is set are updated. This action will take care of creating an additional commit to update 
- `.ci/pipeline_definitions` https://github.com/gardener/terminal-controller-manager/blob/b3c13c87756da2abae154cdc56f87ecd60dbdd5e/.ci/pipeline_definitions#L28-L30
- `go.mod` https://github.com/gardener/terminal-controller-manager/blob/b3c13c87756da2abae154cdc56f87ecd60dbdd5e/go.mod#L3
- In addition, the `golangci-lint.yml` workflow will use the golang version defined in `go.mod` file

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
