### PR TITLE
Use `x.y.0` versions of the Go Toolchain only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,6 +61,15 @@
       separateMinorPatch: true
     },
     {
+      // Do not update to patch versions of the Go Toolchain.
+      // Default golang images set the environment variable GOTOOLCHAIN=local
+      // and we don't want to enforce every (test-)image to be on the latest patch level.
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["go"],
+      "enabled": false
+    },
+    {
       // Group github-actions in one PR.
       groupName: "github-actions",
       matchManagers: ["github-actions"]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,10 +64,10 @@
       // Do not update to patch versions of the Go Toolchain.
       // Default golang images set the environment variable GOTOOLCHAIN=local
       // and we don't want to enforce every (test-)image to be on the latest patch level.
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch"],
-      "matchPackagePatterns": ["go"],
-      "enabled": false
+      matchManagers: ["gomod"],
+      matchUpdateTypes: ["patch"],
+      matchPackagePatterns: ["go"],
+      enabled: false
     },
     {
       // Group github-actions in one PR.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/terminal-controller-manager
 
-go 1.22.2
+go 1.22.0
 
 require (
 	github.com/gardener/gardener v1.93.0


### PR DESCRIPTION
See https://github.com/gardener/gardener/pull/9564 for motivation.

TL;DR: When vendoring this repository, we don't want automatic updates of the version in `go.mod`