### PR TITLE
Read-only config volumeMount

### DIFF
--- a/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/terminal/charts/runtime/templates/controller-manager/deployment.yaml
@@ -130,6 +130,7 @@ spec:
           readOnly: true
         - mountPath: /etc/terminal-controller-manager
           name: terminal-controller-manager-config
+          readOnly: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
**What this PR does / why we need it**:
The `terminal-controller-manager-config` volumeMount does not have to be writeable and can be set to `readOnly` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
