### PR TITLE
Update the component name from `terminal` to `terminal-controller-manager`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,7 @@ terminal-controller-manager:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
-          terminal:
+          terminal-controller-manager:
             inputs:
               repos:
                 source: ~ # default
@@ -54,6 +54,6 @@ terminal-controller-manager:
               slack_cfg_name: 'scp_workspace'
         publish:
           dockerimages:
-            terminal:
+            terminal-controller-manager:
               tag_as_latest: true
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Long story short, the internal CI/CD system has some issues when the image name in an `images.yaml` file differs from the component name of the component.
Starting v1.94.0 gardener-operator manages the terminal-controller-manager and the image name there is `terminal-controller-manager`: https://github.com/gardener/gardener/blob/v1.94.0/imagevector/images.yaml#L47-L50

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The component name is changed from `terminal` to `terminal-controller-manager`.
```
