### PR TITLE
Enhance Terminal Pods with Service Account Token Projection

### DIFF
--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -288,6 +288,24 @@ type ShootRef struct {
 	Name string `json:"name"`
 }
 
+// EqualShootRefs checks if two ShootRef objects are equal
+func EqualShootRefs(ref1, ref2 *ShootRef) bool {
+	if ref1 == nil || ref2 == nil {
+		return false
+	}
+
+	return ref1.Namespace == ref2.Namespace && ref1.Name == ref2.Name
+}
+
+// EqualServiceAccountRefs checks if two ServiceAccountRef objects are equal
+func EqualServiceAccountRefs(ref1, ref2 *corev1.ObjectReference) bool {
+	if ref1 == nil || ref2 == nil {
+		return false
+	}
+
+	return ref1.Namespace == ref2.Namespace && ref1.Name == ref2.Name
+}
+
 // LastError indicates the last occurred error for an operation on a resource.
 type LastError struct {
 	// Description is a human-readable message indicating details about the last error.

--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -270,12 +270,12 @@ type Container struct {
 // ClusterCredentials define the credentials for a kubernetes cluster
 type ClusterCredentials struct {
 	// ServiceAccountRef is a reference to a service account that should be used, usually to manage resources on the same cluster as the service account is residing in
-	// Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+	// Either ShootRef or ServiceAccountRef must be set, but not both.
 	// +optional
 	ServiceAccountRef *corev1.ObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// ShootRef references the shoot cluster. The admin kubeconfig retrieved from the shoots/adminkubeconfig endpoint is used
-	// Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+	// Either ShootRef or ServiceAccountRef must be set, but not both.
 	// +optional
 	ShootRef *ShootRef `json:"shootRef,omitempty"`
 }

--- a/charts/terminal/charts/application/crd-gen/dashboard.gardener.cloud_terminals.yaml
+++ b/charts/terminal/charts/application/crd-gen/dashboard.gardener.cloud_terminals.yaml
@@ -53,7 +53,7 @@ spec:
                       serviceAccountRef:
                         description: |-
                           ServiceAccountRef is a reference to a service account that should be used, usually to manage resources on the same cluster as the service account is residing in
-                          Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+                          Either ShootRef or ServiceAccountRef must be set, but not both.
                         properties:
                           apiVersion:
                             description: API version of the referent.
@@ -99,7 +99,7 @@ spec:
                       shootRef:
                         description: |-
                           ShootRef references the shoot cluster. The admin kubeconfig retrieved from the shoots/adminkubeconfig endpoint is used
-                          Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+                          Either ShootRef or ServiceAccountRef must be set, but not both.
                         properties:
                           name:
                             description: Name is the name of the shoot cluster
@@ -490,7 +490,7 @@ spec:
                       serviceAccountRef:
                         description: |-
                           ServiceAccountRef is a reference to a service account that should be used, usually to manage resources on the same cluster as the service account is residing in
-                          Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+                          Either ShootRef or ServiceAccountRef must be set, but not both.
                         properties:
                           apiVersion:
                             description: API version of the referent.
@@ -536,7 +536,7 @@ spec:
                       shootRef:
                         description: |-
                           ShootRef references the shoot cluster. The admin kubeconfig retrieved from the shoots/adminkubeconfig endpoint is used
-                          Either ShootRef or ServiceAccountRef is mandatory. ShootRef will be used if more than one ref is provided.
+                          Either ShootRef or ServiceAccountRef must be set, but not both.
                         properties:
                           name:
                             description: Name is the name of the shoot cluster

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -572,7 +572,7 @@ func (r *TerminalReconciler) reconcileTerminal(ctx context.Context, targetClient
 		}
 	}
 
-	if err := r.createOrUpdateAttachPodSecret(ctx, hostClientSet, t, labelSet, annotationSet); err != nil {
+	if err := r.createOrUpdateAttachServiceAccount(ctx, hostClientSet, t, labelSet, annotationSet); err != nil {
 		return fmt.Errorf("failed to create or update resources needed for attaching to a pod: %w", err)
 	}
 
@@ -635,7 +635,7 @@ func ensureServiceAccountMembershipCleanup(ctx context.Context, clientSet *garde
 	return nil
 }
 
-func (r *TerminalReconciler) createOrUpdateAttachPodSecret(ctx context.Context, hostClientSet *gardenclient.ClientSet, t *extensionsv1alpha1.Terminal, labelSet *labels.Set, annotationSet *utils.Set) error {
+func (r *TerminalReconciler) createOrUpdateAttachServiceAccount(ctx context.Context, hostClientSet *gardenclient.ClientSet, t *extensionsv1alpha1.Terminal, labelSet *labels.Set, annotationSet *utils.Set) error {
 	if ptr.Deref(t.Spec.Host.TemporaryNamespace, false) {
 		if _, err := hostClientSet.CreateOrUpdateNamespace(ctx, *t.Spec.Host.Namespace, labelSet, annotationSet); err != nil {
 			return err

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -586,10 +586,7 @@ func (r *TerminalReconciler) reconcileTerminal(ctx context.Context, targetClient
 		return fmt.Errorf("failed to create or update kubeconfig secret: %w", err)
 	}
 
-	childCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	accessServiceAccountToken, err := targetClientSet.RequestToken(childCtx, accessServiceAccount, r.getConfig().Controllers.Terminal.TokenRequestExpirationSeconds)
+	accessServiceAccountToken, err := targetClientSet.RequestToken(ctx, accessServiceAccount, r.getConfig().Controllers.Terminal.TokenRequestExpirationSeconds)
 	if err != nil {
 		return fmt.Errorf("failed to request token for access service account: %w", err)
 	}

--- a/test/common.go
+++ b/test/common.go
@@ -285,7 +285,7 @@ func (e Environment) CreateObject(ctx context.Context, obj client.Object, key ty
 	gomega.Expect(e.K8sClient.Create(ctx, obj)).Should(gomega.Succeed())
 	gomega.Eventually(func() bool {
 		err := e.K8sClient.Get(ctx, key, obj)
-		return err == nil
+		return client.IgnoreAlreadyExists(err) == nil
 	}, timeout, interval).Should(gomega.BeTrue())
 }
 

--- a/webhooks/terminal_mutating_handler.go
+++ b/webhooks/terminal_mutating_handler.go
@@ -61,13 +61,13 @@ func (h *TerminalMutator) mutatingTerminalFn(t *v1alpha1.Terminal, admissionReq 
 }
 
 func (h *TerminalMutator) mutateNamespaceIfTemporary(t *v1alpha1.Terminal, terminalIdentifier string) {
+	ns := "term-" + terminalIdentifier
+
 	if ptr.Deref(t.Spec.Host.TemporaryNamespace, false) {
-		ns := "term-host-" + terminalIdentifier
 		t.Spec.Host.Namespace = &ns
 	}
 
 	if ptr.Deref(t.Spec.Target.TemporaryNamespace, false) {
-		ns := "term-target-" + terminalIdentifier
 		t.Spec.Target.Namespace = &ns
 	}
 }

--- a/webhooks/terminal_validating_handler.go
+++ b/webhooks/terminal_validating_handler.go
@@ -245,6 +245,10 @@ func (h *TerminalValidator) validateRequiredCredentials(t *v1alpha1.Terminal) er
 }
 
 func validateRequiredCredential(cred v1alpha1.ClusterCredentials, fldPath *field.Path, honourServiceAccountRef *bool) error {
+	if cred.ShootRef != nil && cred.ServiceAccountRef != nil {
+		return field.Forbidden(fldPath, "only one of 'shootRef' or 'serviceAccountRef' must be set")
+	}
+
 	if !ptr.Deref(honourServiceAccountRef, false) {
 		if cred.ServiceAccountRef != nil {
 			return field.Forbidden(fldPath.Child("serviceAccountRef"), "field is forbidden by configuration")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the following changes:
- Disallow setting `shootRef` and `serviceAccountRef` together
- The defaulting of host and target namespaces, in case of temporary namespaces, has been unified from "term-host-<terminalIdentifier>" and "term-target-<terminalIdentifier>" to "term-<terminalIdentifier>". This enables the mounting of access service accounts into terminal pods.
- Prefer service account token projection for terminal pods when the terminal host and target are in the same cluster and namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enhance terminal pods with service account token projection when the terminal host and target are in the same cluster and namespace
```