### PR TITLE
Fix `.ci/verify` script

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -15,6 +15,8 @@ if [ -z "$SOURCE_PATH" ]; then
 fi
 export SOURCE_PATH="$(readlink -f "$SOURCE_PATH")"
 
+pushd "${SOURCE_PATH}" > /dev/null
+
 export GOLANGCI_LINT_ADDITIONAL_FLAGS="--verbose --timeout 2m"
 export GO_TEST_ADDITIONAL_FLAGS="-race"
 
@@ -25,3 +27,5 @@ else
   # run test instead of test-cov to speed-up jobs, as coverage slows down tests significantly
   make check-generate verify
 fi
+
+popd > /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:
This should fix the build error `make: *** No rule to make target 'verify-extended'.  Stop.`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
