### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/terminal-controller-manager/security/code-scanning/1](https://github.com/gardener/terminal-controller-manager/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow involves checking out the repository and performing a compliance check, it likely only requires `contents: read`. This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
