### PR TITLE
Remove obsolete permission

### DIFF
--- a/charts/terminal/charts/application/templates/controller-manager/clusterrole.yaml
+++ b/charts/terminal/charts/application/templates/controller-manager/clusterrole.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   verbs:
   - get


### PR DESCRIPTION
**What this PR does / why we need it**:
With the removal of `credential.secretRef` from the `Terminal` ([ref](https://github.com/gardener/terminal-controller-manager/pull/320)) resource, the permission to read `secrets` from the (virtual) garden cluster is not required anymore by the `terminal-controller-manager` and is therefore removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Dropped obsolete permission to read secrets from the (virtual) garden cluster.
```
