### PR TITLE
Fix Link to Dashboard documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/terminal-controller-manager)](https://goreportcard.com/report/github.com/gardener/terminal-controller-manager)
 [![reuse compliant](https://reuse.software/badge/reuse-compliant.svg)](https://reuse.software/)
 
-The `terminal-controller-manager` is used for the [webterminal feature](https://github.com/gardener/dashboard/blob/master/docs/Webterminals.md) of the [gardener/dashboard](https://github.com/gardener/dashboard).
+The `terminal-controller-manager` is used for the [webterminal feature](https://github.com/gardener/dashboard/blob/master/docs/operations/webterminals.md) of the [gardener/dashboard](https://github.com/gardener/dashboard).
 
 The `terminal-controller-manager` watches `Terminal` resources under the `dashboard.gardener.cloud/v1alpha1` API group and ensures the desired state on the host and target cluster.
-Host and target cluster can also be the same. For more details and a usage scenario [see docs here](https://github.com/gardener/dashboard/blob/master/docs/Webterminals.md).
+Host and target cluster can also be the same. For more details and a usage scenario [see docs here](https://github.com/gardener/dashboard/blob/master/docs/operations/webterminals.md).
 
 ## Development Setup
 


### PR DESCRIPTION
**What this PR does / why we need it**: Link to Gardener Dashboard documenation is dead

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
