### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -31,7 +31,7 @@ else
   echo "Global Git user.name is already set to $(git config --global user.name)"
 fi
 
-export GOLANGCI_LINT_ADDITIONAL_FLAGS="--verbose --timeout 2m"
+export GOLANGCI_LINT_ADDITIONAL_FLAGS="--verbose --timeout 5m"
 export GO_TEST_ADDITIONAL_FLAGS="-race"
 
 if [ "${TEST_COV+yes}" = yes ] ; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the golangci-lint timeout for the verify script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
