### PR TITLE
ci: Parallelize verification tasks in build workflow to reduce CI time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,12 +55,38 @@ jobs:
       ocm-labels: ${{ toJSON(matrix.args.ocm-labels) }}
       extra-tags: ${{ inputs.mode == 'release' && 'latest' || '' }}
 
-  verify:
+  verify-others:
+      name: Verify (${{ matrix.task }})
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+      env:
+        GO_TEST_RACE: 1
+        GOLANGCI_LINT_VERBOSE: 1
+        GOLANGCI_LINT_TIMEOUT: 5m
+      strategy:
+        fail-fast: false
+        matrix:
+          task: ["check-generate", "lint", "go-test"]
+      steps:
+        - name: Trusted Checkout
+          uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+
+        - name: Set up Go
+          uses: actions/setup-go@v5
+          with:
+            go-version-file: 'go.mod'
+            cache: true
+
+        - name: Run ${{ matrix.task }}
+          run: make ${{ matrix.task }}
+
+  verify-sast:
     uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@master
     permissions:
       contents: read
     with:
       linter: gosec
       run: |
-        TEST_COV=yes \
-          .ci/verify
+        make sast-report
+      go-version: greatest # TODO use go-version-file once supported by cc-utils

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,27 @@ jobs:
           uses: gardener/cc-utils/.github/actions/setup-git-identity@master
 
         - name: Run ${{ matrix.task }}
-          run: make ${{ matrix.task }}
+          shell: bash
+          run: |
+            set -eu
+            mkdir -p /tmp/blobs.d
+            make ${{ matrix.task }} |& tee /tmp/blobs.d/logs.txt
+            tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
+        - name: add-reports-to-component-descriptor
+          if: ${{ matrix.task == 'go-test' }}
+          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+          with:
+            blobs-directory: /tmp/blobs.d
+            ocm-resources: |
+              name: test-results
+              relation: local
+              access:
+                type: localBlob
+                localReference: logs.tar.gz
+              labels:
+                - name: gardener.cloud/purposes
+                  value:
+                    - test
 
   verify-sast:
     uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,14 @@ jobs:
             go-version-file: 'go.mod'
             cache: true
 
+        - name: Set Git user email
+          if: matrix.task == 'check-generate'
+          run: git config --global user.email "gardener@sap.com"
+
+        - name: Set Git user name
+          if: matrix.task == 'check-generate'
+          run: git config --global user.name "Gardener CI/CD"
+
         - name: Run ${{ matrix.task }}
           run: make ${{ matrix.task }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,13 +78,9 @@ jobs:
             go-version-file: 'go.mod'
             cache: true
 
-        - name: Set Git user email
+        - name: Setup Git Identity
           if: matrix.task == 'check-generate'
-          run: git config --global user.email "gardener@sap.com"
-
-        - name: Set Git user name
-          if: matrix.task == 'check-generate'
-          run: git config --global user.name "Gardener CI/CD"
+          uses: gardener/cc-utils/.github/actions/setup-git-identity@master
 
         - name: Run ${{ matrix.task }}
           run: make ${{ matrix.task }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,4 +97,4 @@ jobs:
       linter: gosec
       run: |
         make sast-report
-      go-version: greatest # TODO use go-version-file once supported by cc-utils
+      go-version-file: 'go.mod'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
           uses: gardener/cc-utils/.github/actions/trusted-checkout@master
 
         - name: Set up Go
-          uses: actions/setup-go@v5
+          uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
           with:
             go-version-file: 'go.mod'
             cache: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the `verify` job in `.github/workflows/build.yaml` to enable parallel execution of its sub-tasks: `check-generate`, `lint`, `go-test`, and `sast-report`. Previously, these ran sequentially via `make verify-extended`, taking ~7 minutes. By using a matrix strategy for the first three and reusing the `gardener/cc-utils` `sastlint-ocm.yaml` workflow for SAST, the tasks now run concurrently, reducing completion time to roughly the longest sub-task duration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
