### PR TITLE
migrate cc-utils actions/workflows from @master to @v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
     with:
       mode: ${{ inputs.mode }}
     permissions:
@@ -28,7 +28,7 @@ jobs:
       packages: write
       id-token: write
     secrets: inherit
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1
     strategy:
       matrix:
         args:
@@ -81,7 +81,7 @@ jobs:
           task: ["check-generate", "lint", "go-test"]
       steps:
         - name: Trusted Checkout
-          uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+          uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
 
         - name: Set up Go
           uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
@@ -91,7 +91,7 @@ jobs:
 
         - name: Setup Git Identity
           if: matrix.task == 'check-generate'
-          uses: gardener/cc-utils/.github/actions/setup-git-identity@master
+          uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
 
         - name: Run ${{ matrix.task }}
           shell: bash
@@ -102,7 +102,7 @@ jobs:
             tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
         - name: add-reports-to-component-descriptor
           if: ${{ matrix.task == 'go-test' }}
-          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
           with:
             blobs-directory: /tmp/blobs.d
             ocm-resources: |
@@ -117,7 +117,7 @@ jobs:
                     - test
 
   verify-sast:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1
     permissions:
       contents: read
     with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@master
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@master
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
     needs:
       - build
     secrets: inherit


### PR DESCRIPTION
Switch references to [cc-utils](https://github.com/gardener/cc-utils)
actions and reusable workflows from `@master` to `@v1`.

## Motivation

`v1` is the intended stable branch for downstream users. All internal cross-references
are pinned by commit digest, ensuring a consistent, self-contained snapshot. Coverage
(e.g. pre-qualification) will increase over time.

`master` remains the development branch and continues to work, but is not intended for
downstream consumption.

See the [Reuse and Branching Model](https://gardener.github.io/cc-utils) for details.
