### PR TITLE
chore(charts): deprecate helm charts in favor of gardener-operator

### DIFF
--- a/charts/terminal/Chart.yaml
+++ b/charts/terminal/Chart.yaml
@@ -6,3 +6,4 @@ apiVersion: v1
 description: A Helm chart to deploy the terminal-controller-manager
 name: terminal-controller-manager
 version: 0.1.0
+deprecated: true

--- a/charts/terminal/README.md
+++ b/charts/terminal/README.md
@@ -1,0 +1,8 @@
+# `terminal-controller-manager` Helm Chart
+
+> [!CAUTION]
+> This Helm chart has been deprecated.
+> It will be removed earliest 6 months after deprecation (around November 2026).
+>
+> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the terminal-controller-manager as part of the Gardener control plane.
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).

--- a/charts/terminal/README.md
+++ b/charts/terminal/README.md
@@ -5,4 +5,4 @@
 > It will be removed earliest 6 months after deprecation (around November 2026).
 >
 > We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the terminal-controller-manager as part of the Gardener control plane.
-> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/charts/terminal/charts/application/Chart.yaml
+++ b/charts/terminal/charts/application/Chart.yaml
@@ -6,3 +6,4 @@ apiVersion: v1
 description: A Helm chart to deploy the terminal-controller-manager application related components
 name: terminal-controller-manager-application
 version: 0.1.0
+deprecated: true

--- a/charts/terminal/charts/runtime/Chart.yaml
+++ b/charts/terminal/charts/runtime/Chart.yaml
@@ -6,3 +6,4 @@ apiVersion: v1
 description: A Helm chart to deploy the terminal-controller-manager runtime related components
 name: terminal-controller-manager-runtime
 version: 0.1.0
+deprecated: true


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:

Marks the `terminal-controller-manager` Helm charts as deprecated in favor
of the `gardener-operator` deployment approach.

Adds deprecation notices to Chart.yaml files and README.md documentation to inform
users that these charts will be removed earliest around November 2026.

This aligns with the Gardener project's move away from Helm chart–based deployments
of the controlplane, as announced in gardener/gardener#10706 and completed in
gardener/gardener#14614.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```doc operator
The `terminal-controller-manager` Helm charts are deprecated in favor of `gardener-operator` managed deployments and will be removed earliest around November 2026.
```