### PR TITLE
ci(renovate): use shared gardener/gardener grouping preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     'config:recommended',
     ':semanticCommitsDisabled',
     'customManagers:githubActionsVersions',
+    'github>gardener/ci-infra//config/renovate/group-gardener-updates.json5',
   ],
   labels: [
     'kind/enhancement',
@@ -70,7 +71,6 @@
         'go',
       ],
       matchPackageNames: [
-        'github.com/gardener/gardener',
         'github.com/go-logr/logr',
         'github.com/onsi/ginkgo/v2',
         'github.com/onsi/gomega',


### PR DESCRIPTION
**What this PR does / why we need it**:

Use shared Renovate preset from gardener/ci-infra to group `github.com/gardener/gardener` and `github.com/gardener/gardener/pkg/apis` module updates together, replacing the local package rule.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Shared preset: https://github.com/gardener/ci-infra/blob/master/config/renovate/group-gardener-updates.json5

**Release note**:
```other dependency
NONE
```