### PR TITLE
ci: harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     with:
       mode: ${{ inputs.mode }}
     permissions:
@@ -28,7 +28,7 @@ jobs:
       packages: write
       id-token: write
     secrets: inherit
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     strategy:
       matrix:
         args:
@@ -81,7 +81,7 @@ jobs:
           task: ["check-generate", "lint", "go-test"]
       steps:
         - name: Trusted Checkout
-          uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+          uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
         - name: Set up Go
           uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -91,7 +91,7 @@ jobs:
 
         - name: Setup Git Identity
           if: matrix.task == 'check-generate'
-          uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
+          uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
         - name: Run ${{ matrix.task }}
           shell: bash
@@ -102,7 +102,7 @@ jobs:
             tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
         - name: add-reports-to-component-descriptor
           if: ${{ matrix.task == 'go-test' }}
-          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
           with:
             blobs-directory: /tmp/blobs.d
             ocm-resources: |
@@ -117,7 +117,7 @@ jobs:
                     - test
 
   verify-sast:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       contents: read
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ on:
         description: |
           the mode to use. either `snapshot` or `release`. Will affect effective version, as well
           as target-oci-registry.
+    secrets:
+      dockerhub-auth-token:
+        required: false
+        description: Optional auth token for Docker Hub authentication
 
 jobs:
   prepare:
@@ -27,7 +31,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.dockerhub-auth-token }}
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     strategy:
       matrix:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     permissions:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -8,7 +8,8 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.DOCKERHUB_RO_AUTH }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,8 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.DOCKERHUB_RO_AUTH }}
     permissions:
       contents: read
       id-token: write
@@ -24,7 +25,8 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
-    secrets: inherit
+    secrets:
+      slack-token: ${{ secrets.SLACK_APP_TOKEN_GARDENER_CICD }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,33 @@
+name: Zizmor Workflow Lint
+
+on:
+  push:
+    branches:
+    - master
+    - hotfix-*
+    paths:
+    - '.github/**'
+  pull_request:
+    paths:
+    - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.24.1
+          min-severity: low
+          min-confidence: low
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind enhancement

**What this PR does / why we need it**:

Hardens all GitHub Actions workflows based on findings from [zizmor](https://docs.zizmor.sh/):

- Add zizmor workflow lint as a new CI check
- Replace `secrets: inherit` with explicit secret passing
- Avoid direct use of expression contexts in `run:` scripts
- Disable `persist-credentials` for checkout steps
- Disable setup-go cache in golangci-lint workflow (golangci-lint-action manages its own cache)
- Suppress `unpinned-uses` for same-org actions via inline annotations

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other developer
NONE
```