### PR TITLE
ci(renovate): disable go directive bumps in go.mod

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,10 +34,17 @@
       automerge: true,
     },
     {
+      // Don't bump the go directive in go.mod: gardener depends on TCM, so
+      // raising it here would force gardener's toolchain forward on every TCM
+      // release. The golang builder image in the Dockerfile is handled by the
+      // dockerfile manager and is unaffected.
+      matchManagers: [
+        'gomod',
+      ],
       matchDatasources: [
         'golang-version',
       ],
-      rangeStrategy: 'bump',
+      enabled: false,
     },
     {
       groupName: 'Update tools',


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Disables Renovate's `golang-version` bumps for the `gomod` manager so the `go` directive in `go.mod` is no longer raised automatically. Gardener depends on this controller; bumping the directive here would force gardener's toolchain forward on every TCM release. The Dockerfile golang builder image stays managed by the dockerfile manager and is unaffected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```