### PR TITLE
fix(rbac): grant create on pods/attach for websocket attach

### DIFF
--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -738,7 +738,7 @@ func (r *TerminalReconciler) createOrUpdateAttachServiceAccount(ctx context.Cont
 		{
 			Resources:     []string{"pods/attach"},
 			APIGroups:     []string{corev1.GroupName},
-			Verbs:         []string{"get"},
+			Verbs:         []string{"get", "create"},
 			ResourceNames: []string{podResourceName},
 		},
 		{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/area security
/kind bug

**What this PR does / why we need it**:

Grants the `create` verb in addition to `get` on `pods/attach` in the Role bound to the attach ServiceAccount. Without this verb, terminal attach fails with HTTP 403 against Kubernetes v1.35+ Shoot clusters.

Kubernetes v1.35 enables the `AuthorizePodWebsocketUpgradeCreatePermission` feature gate by default. The kube-apiserver now performs an additional, synthetic authorization check requiring the `create` verb for WebSocket upgrade requests on `pods/{exec,attach,portforward}`. The WebSocket handshake itself is an HTTP GET (RFC 6455), so the `get` verb is still required for the initial request authorization. See KEP-4006.

**Which issue(s) this PR fixes**:
Fixes #504

**Special notes for your reviewer**:

**Release note**:
```fix user
Fix terminal attach against Kubernetes v1.35+ Shoot clusters by granting the `create` verb on `pods/attach` in the attach ServiceAccount's Role, in addition to `get`. Required by the `AuthorizePodWebsocketUpgradeCreatePermission` feature gate (default-on since v1.35).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Terminal pod access permissions to enable additional operational capabilities previously unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->