### PR TITLE
feat(controllers): skip reconciliation for terminals on hibernated shoots

### DIFF
--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -579,6 +579,8 @@ const (
 	EventDeleted = "Deleted"
 	// EventDeleteError indicates that a Delete operation failed.
 	EventDeleteError = "DeleteError"
+	// EventHibernated indicates that reconciliation was skipped because a referenced shoot is hibernated.
+	EventHibernated = "Hibernated"
 
 	// BindingKindClusterRoleBinding will result in a ClusterRoleBinding
 	BindingKindClusterRoleBinding BindingKind = "ClusterRoleBinding"

--- a/controllers/controller_suite_test.go
+++ b/controllers/controller_suite_test.go
@@ -109,6 +109,9 @@ var _ = BeforeSuite(func() {
 	err = indexer.AddProjectNamespace(ctx, e.K8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 
+	err = e.K8sManager.GetFieldIndexer().IndexField(ctx, &dashboardv1alpha1.Terminal{}, TerminalShootRef, IndexTerminalByShootRef)
+	Expect(err).ToNot(HaveOccurred())
+
 	e.Start(ctx)
 })
 

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -36,14 +38,49 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	extensionsv1alpha1 "github.com/gardener/terminal-controller-manager/api/v1alpha1"
 	"github.com/gardener/terminal-controller-manager/internal/gardenclient"
 	"github.com/gardener/terminal-controller-manager/internal/helpers"
 )
+
+// TerminalShootRef is the field index key used to look up Terminal resources by
+// their referenced Shoot (both host and target credentials).
+const TerminalShootRef = "terminal-shoot-ref"
+
+// IndexTerminalByShootRef returns an IndexerFunc that indexes Terminal resources
+// by the Shoot references in their host and target credentials.
+func IndexTerminalByShootRef(obj client.Object) []string {
+	t, ok := obj.(*extensionsv1alpha1.Terminal)
+	if !ok {
+		return nil
+	}
+
+	var keys []string
+
+	addKey := func(ref *extensionsv1alpha1.ShootRef) {
+		if ref == nil {
+			return
+		}
+
+		key := (types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}).String()
+		if slices.Contains(keys, key) {
+			return
+		}
+
+		keys = append(keys, key)
+	}
+
+	addKey(t.Spec.Host.Credentials.ShootRef)
+	addKey(t.Spec.Target.Credentials.ShootRef)
+
+	return keys
+}
 
 // TerminalReconciler reconciles a Terminal object
 type TerminalReconciler struct {
@@ -76,11 +113,71 @@ func (r *TerminalReconciler) SetupWithManager(mgr ctrl.Manager, config extension
 				return false
 			},
 		})).
+		Watches(
+			&gardencorev1beta1.Shoot{},
+			handler.EnqueueRequestsFromMapFunc(r.mapShootToTerminals),
+			builder.WithPredicates(shootWakeUpPredicate()),
+		).
 		Named("main").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: config.MaxConcurrentReconciles,
 		}).
 		Complete(r)
+}
+
+// shootWakeUpPredicate returns a predicate that only passes when a Shoot
+// transitions from hibernated to awake (status.isHibernated: true → false).
+// CreateFunc returns false to prevent the mapping function from running for
+// every existing Shoot during cache sync at startup (see controller-runtime#3466).
+func shootWakeUpPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldShoot, ok := e.ObjectOld.(*gardencorev1beta1.Shoot)
+			if !ok {
+				return false
+			}
+
+			newShoot, ok := e.ObjectNew.(*gardencorev1beta1.Shoot)
+			if !ok {
+				return false
+			}
+
+			return oldShoot.Status.IsHibernated && !newShoot.Status.IsHibernated
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+	}
+}
+
+// mapShootToTerminals enqueues reconcile requests for all Terminals
+// referencing the given Shoot (via host or target credentials). Uses the
+// TerminalShootRef field index for efficient lookup.
+func (r *TerminalReconciler) mapShootToTerminals(ctx context.Context, obj client.Object) []reconcile.Request {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return nil
+	}
+
+	terminalList := &extensionsv1alpha1.TerminalList{}
+	if err := r.List(ctx, terminalList, client.MatchingFields{
+		TerminalShootRef: client.ObjectKeyFromObject(shoot).String(),
+	}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list terminals for shoot", "shoot", client.ObjectKeyFromObject(shoot))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(terminalList.Items))
+	for _, t := range terminalList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&t),
+		})
+	}
+
+	return requests
 }
 
 func (r *TerminalReconciler) getConfig() *extensionsv1alpha1.ControllerManagerConfiguration {
@@ -200,6 +297,22 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 	gardenClientSet := r.ClientSet
 
 	cfg := r.getConfig()
+
+	// Skip reconciliation (not deletion) if any referenced shoot is hibernated.
+	// The Shoot wake-up watch will re-enqueue the Terminal when the shoot comes back.
+	if t.DeletionTimestamp.IsZero() {
+		hibernated, shootKey, err := r.isAnyReferencedShootHibernated(ctx, t)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if hibernated {
+			r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventHibernated,
+				"Referenced shoot %s is hibernated, waiting for wake-up", shootKey.String())
+
+			return ctrl.Result{}, nil
+		}
+	}
 
 	hostClientSet, hostClientSetErr := gardenclient.NewClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Host.Credentials, cfg.HonourServiceAccountRefHostCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds, r.Scheme)
 	targetClientSet, targetClientSetErr := gardenclient.NewClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Target.Credentials, cfg.HonourServiceAccountRefTargetCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds, r.Scheme)
@@ -376,6 +489,47 @@ func isResourceNoLongerAvailableError(err error) (bool, string) {
 	}
 
 	return false, ""
+}
+
+// isAnyReferencedShootHibernated checks whether any Shoot referenced by the
+// Terminal's host or target credentials is currently hibernated. Returns true
+// and the shoot namespaced name if a hibernated shoot is found. Missing shoots
+// are not considered hibernated; other read errors are returned.
+func (r *TerminalReconciler) isAnyReferencedShootHibernated(ctx context.Context, t *extensionsv1alpha1.Terminal) (bool, types.NamespacedName, error) {
+	refs := []*extensionsv1alpha1.ShootRef{
+		t.Spec.Host.Credentials.ShootRef,
+		t.Spec.Target.Credentials.ShootRef,
+	}
+	seen := sets.New[types.NamespacedName]()
+
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+
+		key := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+		if seen.Has(key) {
+			continue
+		}
+
+		seen.Insert(key)
+
+		shoot := &gardencorev1beta1.Shoot{}
+
+		if err := r.Get(ctx, key, shoot); err != nil {
+			if kErros.IsNotFound(err) {
+				continue
+			}
+
+			return false, types.NamespacedName{}, fmt.Errorf("failed to read shoot %s for hibernation check: %w", key.String(), err)
+		}
+
+		if shoot.Status.IsHibernated {
+			return true, key, nil
+		}
+	}
+
+	return false, types.NamespacedName{}, nil
 }
 
 // deleteTerminalDueToMissingResources triggers deletion of a terminal when referenced resources are no longer available.

--- a/controllers/terminal_hibernation_test.go
+++ b/controllers/terminal_hibernation_test.go
@@ -1,0 +1,971 @@
+/*
+SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	dashboardv1alpha1 "github.com/gardener/terminal-controller-manager/api/v1alpha1"
+	"github.com/gardener/terminal-controller-manager/internal/gardenclient"
+	"github.com/gardener/terminal-controller-manager/test"
+)
+
+func newFakeClientWithShoot(shoot *gardencorev1beta1.Shoot, terminals ...*dashboardv1alpha1.Terminal) client.Client {
+	scheme := runtime.NewScheme()
+	Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+	Expect(dashboardv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	objs := []client.Object{}
+	if shoot != nil {
+		objs = append(objs, shoot)
+	}
+
+	for _, t := range terminals {
+		objs = append(objs, t)
+	}
+
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(&dashboardv1alpha1.Terminal{}, TerminalShootRef, IndexTerminalByShootRef)
+
+	return builder.Build()
+}
+
+type failingShootGetClient struct {
+	client.Client
+	err error
+}
+
+func (c *failingShootGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*gardencorev1beta1.Shoot); ok {
+		return c.err
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+type countingShootGetClient struct {
+	client.Client
+	getCount int
+}
+
+func (c *countingShootGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*gardencorev1beta1.Shoot); ok {
+		c.getCount++
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func newTestReconciler(c client.Client) *TerminalReconciler {
+	return &TerminalReconciler{
+		ClientSet: gardenclient.NewClientSet(
+			&rest.Config{Host: "https://127.0.0.1:0"},
+			c,
+			nil,
+		),
+		Scheme:                      c.Scheme(),
+		Recorder:                    record.NewFakeRecorder(100),
+		Config:                      nil,
+		ReconcilerCountPerNamespace: map[string]int{},
+	}
+}
+
+// drainEvents reads all currently-buffered events from a FakeRecorder without
+// blocking. It does not close the channel, so the recorder remains usable.
+func drainEvents(rec *record.FakeRecorder) []string {
+	var events []string
+
+	for {
+		select {
+		case ev := <-rec.Events:
+			events = append(events, ev)
+		default:
+			return events
+		}
+	}
+}
+
+var _ = Describe("Shoot Hibernation", func() {
+	Describe("IndexTerminalByShootRef", func() {
+		It("should return empty for terminal without shoot refs", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(BeEmpty())
+		})
+
+		It("should index target shoot ref", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/my-shoot"))
+		})
+
+		It("should index host shoot ref", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "host-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/host-shoot"))
+		})
+
+		It("should index both host and target shoot refs when different", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "host-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "target-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/host-shoot", "garden-project/target-shoot"))
+		})
+
+		It("should deduplicate when host and target reference the same shoot", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "same-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "same-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/same-shoot"))
+			Expect(keys).To(HaveLen(1))
+		})
+
+		It("should return nil for non-Terminal objects", func() {
+			keys := IndexTerminalByShootRef(&corev1.Pod{})
+			Expect(keys).To(BeNil())
+		})
+	})
+
+	Describe("shootWakeUpPredicate", func() {
+		var pred = shootWakeUpPredicate()
+
+		It("should reject create events", func() {
+			result := pred.Create(event.CreateEvent{
+				Object: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject delete events", func() {
+			result := pred.Delete(event.DeleteEvent{
+				Object: &gardencorev1beta1.Shoot{},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should accept update from hibernated to awake", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should reject update from awake to hibernated", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update when both awake", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update when both hibernated", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update with non-Shoot objects", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &corev1.Pod{},
+				ObjectNew: &corev1.Pod{},
+			})
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Describe("mapShootToTerminals", func() {
+		It("should map a shoot to terminals referencing it", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-shoot",
+					Namespace: "garden-project",
+				},
+			}
+			terminal := &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-terminal",
+					Namespace: "term-ns",
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+						Namespace: ptr.To("term-ns"),
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+						Namespace:                  ptr.To("term-ns"),
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+
+			fakeClient := newFakeClientWithShoot(shoot, terminal)
+			r := newTestReconciler(fakeClient)
+
+			requests := r.mapShootToTerminals(context.Background(), shoot)
+
+			Expect(requests).To(ContainElement(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "term-ns",
+					Name:      "my-terminal",
+				},
+			}))
+		})
+
+		It("should return empty for a shoot not referenced by any terminal", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-shoot",
+					Namespace: "garden-project",
+				},
+			}
+
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+
+			requests := r.mapShootToTerminals(context.Background(), shoot)
+
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Describe("isAnyReferencedShootHibernated", func() {
+		It("should return false when no shoot refs exist", func() {
+			fakeClient := newFakeClientWithShoot(nil)
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+				},
+			}
+			hibernated, _, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeFalse())
+		})
+
+		It("should return true when target shoot is hibernated", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-shoot",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					IsHibernated: true,
+				},
+			}
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "hib-shoot",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, key, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeTrue())
+			Expect(key).To(Equal(types.NamespacedName{Namespace: "garden-project", Name: "hib-shoot"}))
+		})
+
+		It("should return true when host shoot is hibernated", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-host",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					IsHibernated: true,
+				},
+			}
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "hib-host",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+				},
+			}
+
+			hibernated, key, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeTrue())
+			Expect(key).To(Equal(types.NamespacedName{Namespace: "garden-project", Name: "hib-host"}))
+		})
+
+		It("should return false when shoot is not hibernated", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "awake-shoot",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					IsHibernated: false,
+				},
+			}
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "awake-shoot",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, _, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeFalse())
+		})
+
+		It("should treat a missing shoot as not hibernated", func() {
+			fakeClient := newFakeClientWithShoot(nil)
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "nonexistent-ns",
+								Name:      "nonexistent-shoot",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, _, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeFalse())
+		})
+
+		It("should return non-NotFound shoot read errors", func() {
+			readErr := errors.New("cache unavailable")
+			fakeClient := &failingShootGetClient{
+				Client: newFakeClientWithShoot(nil),
+				err:    readErr,
+			}
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "shoot",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, key, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(hibernated).To(BeFalse())
+			Expect(key).To(Equal(types.NamespacedName{}))
+			Expect(err).To(MatchError(ContainSubstring("failed to read shoot garden-project/shoot for hibernation check: cache unavailable")))
+			Expect(errors.Is(err, readErr)).To(BeTrue())
+		})
+
+		It("should read duplicate shoot refs only once", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "awake",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+			}
+			fakeClient := &countingShootGetClient{
+				Client: newFakeClientWithShoot(shoot),
+			}
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "awake",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "awake",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, key, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeFalse())
+			Expect(key).To(Equal(types.NamespacedName{}))
+			Expect(fakeClient.getCount).To(Equal(1))
+		})
+
+		It("should detect hibernation on either ref when both host and target reference different shoots", func() {
+			awakeShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "awake",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+			}
+			hibShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hibernated",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+			}
+
+			scheme := runtime.NewScheme()
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(dashboardv1alpha1.AddToScheme(scheme)).To(Succeed())
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(awakeShoot, hibShoot).
+				Build()
+
+			r := newTestReconciler(fakeClient)
+
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "awake",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "hibernated",
+							},
+						},
+					},
+				},
+			}
+
+			hibernated, key, err := r.isAnyReferencedShootHibernated(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hibernated).To(BeTrue())
+			Expect(key).To(Equal(types.NamespacedName{Namespace: "garden-project", Name: "hibernated"}))
+		})
+	})
+
+	Describe("Shoot hibernation wake-up (integration)", func() {
+		const (
+			timeout  = time.Second * 30
+			interval = time.Millisecond * 250
+		)
+
+		var (
+			suffix            string
+			terminalNamespace string
+			hostNamespace     string
+			shootNamespace    string
+			shoot             *gardencorev1beta1.Shoot
+			terminal          *dashboardv1alpha1.Terminal
+			terminalKey       types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			suffix = test.StringWithCharset(randomLength, charset)
+			terminalNamespace = "test-hib-term-ns-" + suffix
+			hostNamespace = "test-hib-host-ns-" + suffix
+			shootNamespace = "garden-hib-" + suffix
+
+			By("Creating namespaces")
+
+			for _, ns := range []string{terminalNamespace, hostNamespace, shootNamespace} {
+				e.CreateObject(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, types.NamespacedName{Name: ns}, timeout, interval)
+			}
+
+			By("Creating host service account")
+			e.AddClusterAdminServiceAccount(ctx, "hib-host-sa", hostNamespace, timeout, interval)
+
+			By("Creating Project for Shoot namespace")
+
+			project := &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: "hib-" + suffix},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: &shootNamespace,
+				},
+			}
+			e.CreateObject(ctx, project, client.ObjectKeyFromObject(project), timeout, interval)
+
+			By("Creating Shoot")
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-shoot-" + suffix,
+					Namespace: shootNamespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: ptr.To("secretbinding"),
+					CloudProfileName:  ptr.To("cloudprofile1"),
+					Region:            "eu-central-1",
+					Provider: gardencorev1beta1.Provider{
+						Type: "foo-provider",
+						Workers: []gardencorev1beta1.Worker{
+							{
+								Name:    "cpu-worker",
+								Minimum: 1,
+								Maximum: 1,
+								Machine: gardencorev1beta1.Machine{
+									Type: "large",
+									Image: &gardencorev1beta1.ShootMachineImage{
+										Name:    "some-image",
+										Version: ptr.To("1.0.0"),
+									},
+								},
+							},
+						},
+					},
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.32.0",
+					},
+					Networking: &gardencorev1beta1.Networking{
+						Type: ptr.To("foo-networking"),
+					},
+				},
+			}
+			Expect(e.K8sClient.Create(ctx, shoot)).To(Succeed())
+
+			By("Setting Shoot status to hibernated")
+
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Status.IsHibernated = true
+			Expect(e.K8sClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+
+			By("Creating Terminal referencing the hibernated Shoot")
+
+			terminal = &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-terminal-" + suffix,
+					Namespace: terminalNamespace,
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Kind:      rbacv1.ServiceAccountKind,
+								Name:      "hib-host-sa",
+								Namespace: hostNamespace,
+							},
+						},
+						Namespace: &hostNamespace,
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: shootNamespace,
+								Name:      shoot.Name,
+							},
+						},
+						Namespace:                  &hostNamespace,
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+			terminalKey = types.NamespacedName{Name: terminal.Name, Namespace: terminal.Namespace}
+			Expect(e.K8sClient.Create(ctx, terminal)).To(Succeed())
+		})
+
+		It("should skip reconciliation while shoot is hibernated, then reconcile after wake-up", func() {
+			By("Waiting for the hibernation event proving the skip path ran")
+			Eventually(func(g Gomega) {
+				events := &corev1.EventList{}
+				err := e.K8sClient.List(ctx, events,
+					client.InNamespace(terminalNamespace),
+					client.MatchingFields{"involvedObject.name": terminal.Name, "involvedObject.kind": "Terminal"})
+				g.Expect(err).To(Not(HaveOccurred()))
+
+				found := false
+
+				for _, ev := range events.Items {
+					if ev.Reason == dashboardv1alpha1.EventHibernated {
+						found = true
+						break
+					}
+				}
+
+				g.Expect(found).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			By("Ensuring the terminal is NOT progressing to ready state while hibernated")
+			Consistently(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+
+				g.Expect(t.Status.AttachServiceAccountName).To(BeNil())
+				g.Expect(t.Status.PodName).To(BeNil())
+			}, 3*time.Second, interval).Should(Succeed())
+
+			By("Waking the Shoot by clearing IsHibernated")
+
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Status.IsHibernated = false
+			Expect(e.K8sClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+
+			By("Triggering a reconcile to confirm hibernation check no longer blocks")
+			Eventually(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+
+				if t.Annotations == nil {
+					t.Annotations = map[string]string{}
+				}
+
+				t.Annotations["test-wake-trigger"] = "true"
+				g.Expect(e.K8sClient.Update(ctx, t)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			By("Waiting for the terminal to progress past hibernation check (LastOperation transitions away from Succeeded)")
+			Eventually(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+				g.Expect(t.Status.LastOperation).ToNot(BeNil())
+				g.Expect(t.Status.LastOperation.State).To(Equal(dashboardv1alpha1.LastOperationStateError))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("handleTerminal hibernation skip (unit)", func() {
+		It("should return early without error when target shoot is hibernated", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-shoot",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+			}
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+			r.Config = test.DefaultConfiguration()
+			r.ReconcilerCountPerNamespace = map[string]int{}
+
+			t := &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-terminal",
+					Namespace: "term-ns",
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+						Namespace: ptr.To("term-ns"),
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "hib-shoot",
+							},
+						},
+						Namespace:                  ptr.To("term-ns"),
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+
+			result, err := r.handleTerminal(context.Background(), t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// Verify a hibernation event was emitted, proving the skip path ran.
+			rec, ok := r.Recorder.(*record.FakeRecorder)
+			Expect(ok).To(BeTrue())
+			Expect(rec.Events).To(Receive(ContainSubstring(dashboardv1alpha1.EventHibernated)))
+		})
+
+		It("should run deletion path even when target shoot is hibernated", func() {
+			now := metav1.Now()
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-shoot-del",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+			}
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+			r.Config = test.DefaultConfiguration()
+			r.ReconcilerCountPerNamespace = map[string]int{}
+
+			t := &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "my-terminal-del",
+					Namespace:         "term-ns",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{dashboardv1alpha1.TerminalName},
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{Name: "sa", Namespace: "ns"},
+						},
+						Namespace: ptr.To("term-ns"),
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "hib-shoot-del",
+							},
+						},
+						Namespace:                  ptr.To("term-ns"),
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+
+			// We don't care whether deleteTerminal succeeds against the fake
+			// client — only that the hibernation skip was NOT taken and the
+			// deletion path was entered.
+			_, _ = r.handleTerminal(context.Background(), t)
+
+			rec, ok := r.Recorder.(*record.FakeRecorder)
+			Expect(ok).To(BeTrue())
+
+			events := drainEvents(rec)
+			Expect(events).ToNot(ContainElement(ContainSubstring(dashboardv1alpha1.EventHibernated)))
+			Expect(events).To(ContainElement(ContainSubstring(dashboardv1alpha1.EventDeleting)))
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -24,11 +24,14 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -89,6 +92,17 @@ func main() {
 			BindAddress:    fmt.Sprintf("%s:%d", cmConfig.Server.Metrics.BindAddress, cmConfig.Server.Metrics.Port),
 			CertDir:        metricsServerCertDir,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
+		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&gardencorev1beta1.Shoot{}: {
+					// Transform strips Shoot objects down to the minimum fields needed
+					// by the terminal controller. Only metadata and status.isHibernated
+					// are preserved in the cache. If you need additional Shoot fields,
+					// add them here — otherwise cache reads return zero values silently.
+					Transform: transformShoot(),
+				},
+			},
 		},
 		LeaderElection:                ptr.Deref(cmConfig.LeaderElection.LeaderElect, true),
 		LeaderElectionResourceLock:    cmConfig.LeaderElection.ResourceLock,
@@ -183,6 +197,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Terminal{}, controllers.TerminalShootRef, controllers.IndexTerminalByShootRef); err != nil {
+		setupLog.Error(err, "unable to add terminal shoot ref field indexer")
+		os.Exit(1)
+	}
+
 	setupLog.Info("starting manager")
 
 	if err := mgr.Start(ctx); err != nil {
@@ -268,6 +287,29 @@ func readFile(configFile string, cfg *v1alpha1.ControllerManagerConfiguration) e
 	}
 
 	return json.Unmarshal(jsonData, cfg)
+}
+
+func transformShoot() toolscache.TransformFunc {
+	return func(obj interface{}) (interface{}, error) {
+		shoot, ok := obj.(*gardencorev1beta1.Shoot)
+		if !ok {
+			return obj, nil
+		}
+
+		stripped := &gardencorev1beta1.Shoot{
+			TypeMeta: shoot.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            shoot.Name,
+				Namespace:       shoot.Namespace,
+				ResourceVersion: shoot.ResourceVersion,
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				IsHibernated: shoot.Status.IsHibernated,
+			},
+		}
+
+		return stripped, nil
+	}
 }
 
 func validateConfig(cfg *v1alpha1.ControllerManagerConfiguration) error {

--- a/test/common.go
+++ b/test/common.go
@@ -157,6 +157,7 @@ func New(mutator admission.Handler, validator admission.Handler) Environment {
 			ControlPlaneStopTimeout:  2 * time.Minute,
 		},
 		GardenerAPIServer: &gardenenvtest.GardenerAPIServer{
+			Args:        []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator"},
 			StopTimeout: 2 * time.Minute,
 		},
 	}


### PR DESCRIPTION
/area robustness
/kind enhancement

**What this PR does / why we need it**:

When a Shoot referenced by a Terminal's host or target credentials is hibernated, the terminal controller now skips reconciliation and emits a `Hibernated` event. A Shoot watch with a wake-up predicate (`IsHibernated: true → false`) automatically re-enqueues affected Terminals when the Shoot comes back.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature operator
Terminal reconciliation is now skipped while a referenced Shoot is hibernated, reducing unnecessary errors and retries. Terminals are automatically re-reconciled when the Shoot wakes up.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now recognize a new **Hibernated** state for related shoot resources.
  * Terminals automatically pause progress while a referenced shoot is hibernated and resume once it wakes up.
  * Terminal events are now emitted when hibernation prevents processing, improving status visibility.

* **Bug Fixes**
  * Terminal reconciliations are now retriggered when a shoot transitions from hibernated to active, reducing missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->