### PR TITLE
feat(controllers): skip reconciliation for terminals on hibernated shoots

### DIFF
--- a/api/v1alpha1/terminal_types.go
+++ b/api/v1alpha1/terminal_types.go
@@ -579,6 +579,8 @@ const (
 	EventDeleted = "Deleted"
 	// EventDeleteError indicates that a Delete operation failed.
 	EventDeleteError = "DeleteError"
+	// EventHibernated indicates that reconciliation was skipped because a referenced shoot is hibernated.
+	EventHibernated = "Hibernated"
 
 	// BindingKindClusterRoleBinding will result in a ClusterRoleBinding
 	BindingKindClusterRoleBinding BindingKind = "ClusterRoleBinding"

--- a/charts/terminal/charts/application/templates/controller-manager/clusterrole.yaml
+++ b/charts/terminal/charts/application/templates/controller-manager/clusterrole.yaml
@@ -64,6 +64,14 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.gardener.cloud
+  resources:
   - shoots/adminkubeconfig
   verbs:
   - create

--- a/controllers/controller_suite_test.go
+++ b/controllers/controller_suite_test.go
@@ -109,6 +109,9 @@ var _ = BeforeSuite(func() {
 	err = indexer.AddProjectNamespace(ctx, e.K8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 
+	err = e.K8sManager.GetFieldIndexer().IndexField(ctx, &dashboardv1alpha1.Terminal{}, TerminalShootRef, IndexTerminalByShootRef)
+	Expect(err).ToNot(HaveOccurred())
+
 	e.Start(ctx)
 })
 

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -633,7 +633,7 @@ func (r *TerminalReconciler) deleteExternalDependency(ctx context.Context, targe
 		lastErrors = append(lastErrors, hostErr)
 	}
 
-	if len(lastErrors) >= 0 {
+	if len(lastErrors) > 0 {
 		return lastErrors
 	}
 

--- a/controllers/terminal_controller.go
+++ b/controllers/terminal_controller.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -36,14 +38,55 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	extensionsv1alpha1 "github.com/gardener/terminal-controller-manager/api/v1alpha1"
 	"github.com/gardener/terminal-controller-manager/internal/gardenclient"
 	"github.com/gardener/terminal-controller-manager/internal/helpers"
 )
+
+const (
+	// TerminalShootRef is the field index key used to look up Terminal resources by
+	// their referenced Shoot (both host and target credentials).
+	TerminalShootRef = "terminal-shoot-ref"
+
+	shootHibernationRequeueAfter = time.Hour
+)
+
+var errShootHibernated = errors.New("shoot is hibernated")
+
+// IndexTerminalByShootRef returns an IndexerFunc that indexes Terminal resources
+// by the Shoot references in their host and target credentials.
+func IndexTerminalByShootRef(obj client.Object) []string {
+	t, ok := obj.(*extensionsv1alpha1.Terminal)
+	if !ok {
+		return nil
+	}
+
+	var keys []string
+
+	addKey := func(ref *extensionsv1alpha1.ShootRef) {
+		if ref == nil {
+			return
+		}
+
+		key := (types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}).String()
+		if slices.Contains(keys, key) {
+			return
+		}
+
+		keys = append(keys, key)
+	}
+
+	addKey(t.Spec.Host.Credentials.ShootRef)
+	addKey(t.Spec.Target.Credentials.ShootRef)
+
+	return keys
+}
 
 // TerminalReconciler reconciles a Terminal object
 type TerminalReconciler struct {
@@ -76,11 +119,71 @@ func (r *TerminalReconciler) SetupWithManager(mgr ctrl.Manager, config extension
 				return false
 			},
 		})).
+		Watches(
+			&gardencorev1beta1.Shoot{},
+			handler.EnqueueRequestsFromMapFunc(r.mapShootToTerminals),
+			builder.WithPredicates(shootWakeUpPredicate()),
+		).
 		Named("main").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: config.MaxConcurrentReconciles,
 		}).
 		Complete(r)
+}
+
+// shootWakeUpPredicate returns a predicate that only passes when a Shoot
+// transitions from hibernated to awake (status.isHibernated: true → false).
+// CreateFunc returns false to prevent the mapping function from running for
+// every existing Shoot during cache sync at startup (see controller-runtime#3466).
+func shootWakeUpPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldShoot, ok := e.ObjectOld.(*gardencorev1beta1.Shoot)
+			if !ok {
+				return false
+			}
+
+			newShoot, ok := e.ObjectNew.(*gardencorev1beta1.Shoot)
+			if !ok {
+				return false
+			}
+
+			return oldShoot.Status.IsHibernated && !newShoot.Status.IsHibernated
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+	}
+}
+
+// mapShootToTerminals enqueues reconcile requests for all Terminals
+// referencing the given Shoot (via host or target credentials). Uses the
+// TerminalShootRef field index for efficient lookup.
+func (r *TerminalReconciler) mapShootToTerminals(ctx context.Context, obj client.Object) []reconcile.Request {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return nil
+	}
+
+	terminalList := &extensionsv1alpha1.TerminalList{}
+	if err := r.List(ctx, terminalList, client.MatchingFields{
+		TerminalShootRef: client.ObjectKeyFromObject(shoot).String(),
+	}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list terminals for shoot", "shoot", client.ObjectKeyFromObject(shoot))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(terminalList.Items))
+	for _, t := range terminalList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&t),
+		})
+	}
+
+	return requests
 }
 
 func (r *TerminalReconciler) getConfig() *extensionsv1alpha1.ControllerManagerConfiguration {
@@ -179,18 +282,15 @@ func (r *TerminalReconciler) handleRequest(ctx context.Context, req ctrl.Request
 	}
 
 	result, err := r.handleTerminal(ctx, t)
-	if updateErr := r.patchTerminalStatus(ctx, t, func(terminal *extensionsv1alpha1.Terminal) error {
-		if err != nil {
+	if err != nil {
+		if updateErr := r.patchTerminalStatus(ctx, t, func(terminal *extensionsv1alpha1.Terminal) error {
 			terminal.Status.LastError = lastError(err.Error())
 			terminal.Status.LastOperation = reconcileError(lastOperationType, err.Error())
-		} else {
-			terminal.Status.LastError = nil
-			terminal.Status.LastOperation = reconcileSucceeded(lastOperationType, "Terminal has been successfully reconciled.")
-		}
 
-		return nil
-	}); client.IgnoreNotFound(updateErr) != nil {
-		return ctrl.Result{}, errors.Join(updateErr, err)
+			return nil
+		}); client.IgnoreNotFound(updateErr) != nil {
+			return ctrl.Result{}, errors.Join(updateErr, err)
+		}
 	}
 
 	return result, err
@@ -201,8 +301,8 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 
 	cfg := r.getConfig()
 
-	hostClientSet, hostClientSetErr := gardenclient.NewClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Host.Credentials, cfg.HonourServiceAccountRefHostCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds, r.Scheme)
-	targetClientSet, targetClientSetErr := gardenclient.NewClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Target.Credentials, cfg.HonourServiceAccountRefTargetCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds, r.Scheme)
+	hostClientSet, hostClientSetErr := r.newClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Host.Credentials, cfg.HonourServiceAccountRefHostCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds)
+	targetClientSet, targetClientSetErr := r.newClientSetFromClusterCredentials(ctx, gardenClientSet, t.Spec.Target.Credentials, cfg.HonourServiceAccountRefTargetCluster, cfg.Controllers.Terminal.TokenRequestExpirationSeconds)
 
 	if !t.DeletionTimestamp.IsZero() {
 		return r.deleteTerminal(ctx, t, hostClientSetErr, targetClientSetErr, targetClientSet, hostClientSet)
@@ -217,7 +317,9 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 			return r.deleteTerminalDueToMissingResources(ctx, t)
 		}
 
-		return ctrl.Result{}, hostClientSetErr
+		if !isShootHibernatedError(hostClientSetErr) {
+			return ctrl.Result{}, hostClientSetErr
+		}
 	}
 
 	if targetClientSetErr != nil {
@@ -229,7 +331,23 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 			return r.deleteTerminalDueToMissingResources(ctx, t)
 		}
 
-		return ctrl.Result{}, targetClientSetErr
+		if !isShootHibernatedError(targetClientSetErr) {
+			return ctrl.Result{}, targetClientSetErr
+		}
+	}
+
+	if isShootHibernatedError(hostClientSetErr) || isShootHibernatedError(targetClientSetErr) {
+		r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventHibernated,
+			"Reconciliation is waiting for a referenced shoot to wake from hibernation")
+
+		if err := r.patchTerminalOperationProcessing(ctx, t,
+			extensionsv1alpha1.LastOperationTypeReconcile,
+			"Terminal reconciliation is waiting for a referenced shoot to wake from hibernation.",
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{RequeueAfter: shootHibernationRequeueAfter}, nil
 	}
 
 	if err := r.ensureAdmissionWebhookConfigured(ctx, gardenClientSet, t); err != nil {
@@ -246,7 +364,7 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 		// the needed labels will be set eventually, requeue won't change that
 		r.recordEventAndLog(ctx, t, corev1.EventTypeWarning, extensionsv1alpha1.EventReconcileError, "Transient problem - %s. Skipping...", err.Error())
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.patchTerminalOperationError(ctx, t, extensionsv1alpha1.LastOperationTypeReconcile, err.Error())
 	}
 
 	annotationSet, err := t.NewAnnotationsSet()
@@ -254,7 +372,7 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 		// the needed annotations will be set eventually, requeue won't change that
 		r.recordEventAndLog(ctx, t, corev1.EventTypeWarning, extensionsv1alpha1.EventReconcileError, "Transient problem - %s. Skipping...", err.Error())
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.patchTerminalOperationError(ctx, t, extensionsv1alpha1.LastOperationTypeReconcile, err.Error())
 	}
 
 	r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventReconciling, "Reconciling Terminal state")
@@ -266,7 +384,7 @@ func (r *TerminalReconciler) handleTerminal(ctx context.Context, t *extensionsv1
 
 	r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventReconciled, "Reconciled Terminal state")
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.patchTerminalOperationSucceeded(ctx, t, extensionsv1alpha1.LastOperationTypeReconcile, "Terminal has been successfully reconciled.")
 }
 
 func (r *TerminalReconciler) ensureFinalizer(ctx context.Context, t *extensionsv1alpha1.Terminal) error {
@@ -316,6 +434,9 @@ func (r *TerminalReconciler) deleteTerminal(ctx context.Context, t *extensionsv1
 		if ok, cause := isResourceNoLongerAvailableError(hostClientSetErr); ok {
 			r.recordEventAndLog(ctx, t, corev1.EventTypeWarning, extensionsv1alpha1.EventDeleting,
 				"Host cluster credentials no longer available due to %s during deletion, continuing cleanup: %s", cause, hostClientSetErr.Error())
+		} else if isShootHibernatedError(hostClientSetErr) {
+			r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleting,
+				"Host cluster cleanup is deferred because the referenced shoot is hibernated")
 		} else {
 			return ctrl.Result{}, hostClientSetErr
 		}
@@ -325,12 +446,15 @@ func (r *TerminalReconciler) deleteTerminal(ctx context.Context, t *extensionsv1
 		if ok, cause := isResourceNoLongerAvailableError(targetClientSetErr); ok {
 			r.recordEventAndLog(ctx, t, corev1.EventTypeWarning, extensionsv1alpha1.EventDeleting,
 				"Target cluster credentials no longer available due to %s during deletion, continuing cleanup: %s", cause, targetClientSetErr.Error())
+		} else if isShootHibernatedError(targetClientSetErr) {
+			r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleting,
+				"Target cluster cleanup is deferred because the referenced shoot is hibernated")
 		} else {
 			return ctrl.Result{}, targetClientSetErr
 		}
 	}
 
-	r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleting, "Deleting external dependencies")
+	r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleting, "Processing external dependency deletion")
 	// our finalizer is present, so lets handle our external dependency
 
 	if deletionErrors := r.deleteExternalDependency(ctx, targetClientSet, hostClientSet, t); deletionErrors != nil {
@@ -342,6 +466,20 @@ func (r *TerminalReconciler) deleteTerminal(ctx context.Context, t *extensionsv1
 		}
 
 		return ctrl.Result{}, errors.New(strings.Join(errStrings, "\n"))
+	}
+
+	if isShootHibernatedError(hostClientSetErr) || isShootHibernatedError(targetClientSetErr) {
+		r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleting,
+			"External dependency deletion is waiting for deferred shoot cleanup")
+
+		if err := r.patchTerminalOperationProcessing(ctx, t,
+			extensionsv1alpha1.LastOperationTypeDelete,
+			"Terminal deletion is waiting for a referenced shoot to wake from hibernation.",
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{RequeueAfter: shootHibernationRequeueAfter}, nil
 	}
 
 	r.recordEventAndLog(ctx, t, corev1.EventTypeNormal, extensionsv1alpha1.EventDeleted, "Deleted external dependencies")
@@ -376,6 +514,46 @@ func isResourceNoLongerAvailableError(err error) (bool, string) {
 	}
 
 	return false, ""
+}
+
+func isShootHibernatedError(err error) bool {
+	return errors.Is(err, errShootHibernated)
+}
+
+func (r *TerminalReconciler) newClientSetFromClusterCredentials(ctx context.Context, gardenClientSet *gardenclient.ClientSet, credentials extensionsv1alpha1.ClusterCredentials, honourServiceAccountRef *bool, expirationSeconds *int64) (*gardenclient.ClientSet, error) {
+	hibernated, err := r.isShootRefHibernated(ctx, credentials.ShootRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if hibernated {
+		return nil, errShootHibernated
+	}
+
+	return gardenclient.NewClientSetFromClusterCredentials(ctx, gardenClientSet, credentials, honourServiceAccountRef, expirationSeconds, r.Scheme)
+}
+
+// isShootRefHibernated checks whether the given ShootRef points to a Shoot that
+// is currently hibernated. Missing Shoot resources are not considered
+// hibernated, so the normal client creation path can surface the underlying
+// credential/resource error.
+func (r *TerminalReconciler) isShootRefHibernated(ctx context.Context, ref *extensionsv1alpha1.ShootRef) (bool, error) {
+	if ref == nil {
+		return false, nil
+	}
+
+	shoot := &gardencorev1beta1.Shoot{}
+
+	key := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+	if err := r.Get(ctx, key, shoot); err != nil {
+		if kErros.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to read shoot %s for hibernation check: %w", key.String(), err)
+	}
+
+	return shoot.Status.IsHibernated, nil
 }
 
 // deleteTerminalDueToMissingResources triggers deletion of a terminal when referenced resources are no longer available.
@@ -791,6 +969,33 @@ func (r *TerminalReconciler) patchTerminalStatus(ctx context.Context, t *extensi
 	}
 
 	return r.Status().Patch(ctx, terminal, patch)
+}
+
+func (r *TerminalReconciler) patchTerminalOperationProcessing(ctx context.Context, t *extensionsv1alpha1.Terminal, operationType extensionsv1alpha1.LastOperationType, description string) error {
+	return r.patchTerminalStatus(ctx, t, func(terminal *extensionsv1alpha1.Terminal) error {
+		terminal.Status.LastError = nil
+		terminal.Status.LastOperation = reconcileProcessing(operationType, description)
+
+		return nil
+	})
+}
+
+func (r *TerminalReconciler) patchTerminalOperationSucceeded(ctx context.Context, t *extensionsv1alpha1.Terminal, operationType extensionsv1alpha1.LastOperationType, description string) error {
+	return r.patchTerminalStatus(ctx, t, func(terminal *extensionsv1alpha1.Terminal) error {
+		terminal.Status.LastError = nil
+		terminal.Status.LastOperation = reconcileSucceeded(operationType, description)
+
+		return nil
+	})
+}
+
+func (r *TerminalReconciler) patchTerminalOperationError(ctx context.Context, t *extensionsv1alpha1.Terminal, operationType extensionsv1alpha1.LastOperationType, description string) error {
+	return r.patchTerminalStatus(ctx, t, func(terminal *extensionsv1alpha1.Terminal) error {
+		terminal.Status.LastError = lastError(description)
+		terminal.Status.LastOperation = reconcileError(operationType, description)
+
+		return nil
+	})
 }
 
 func (r *TerminalReconciler) createOrUpdateAccessServiceAccount(ctx context.Context, targetClientSet *gardenclient.ClientSet, t *extensionsv1alpha1.Terminal, labelSet *labels.Set, annotationSet *helpers.Set) (*corev1.ServiceAccount, error) {

--- a/controllers/terminal_hibernation_test.go
+++ b/controllers/terminal_hibernation_test.go
@@ -1,0 +1,707 @@
+/*
+SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kErros "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	dashboardv1alpha1 "github.com/gardener/terminal-controller-manager/api/v1alpha1"
+	"github.com/gardener/terminal-controller-manager/internal/gardenclient"
+	"github.com/gardener/terminal-controller-manager/test"
+)
+
+func newFakeClientWithObjects(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+	Expect(dashboardv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&dashboardv1alpha1.Terminal{}).
+		WithIndex(&dashboardv1alpha1.Terminal{}, TerminalShootRef, IndexTerminalByShootRef).
+		Build()
+}
+
+func newFakeClientWithShoot(shoot *gardencorev1beta1.Shoot, terminals ...*dashboardv1alpha1.Terminal) client.Client {
+	objs := []client.Object{}
+	if shoot != nil {
+		objs = append(objs, shoot)
+	}
+
+	for _, t := range terminals {
+		objs = append(objs, t)
+	}
+
+	return newFakeClientWithObjects(objs...)
+}
+
+func newTestReconciler(c client.Client) *TerminalReconciler {
+	return &TerminalReconciler{
+		ClientSet: gardenclient.NewClientSet(
+			&rest.Config{Host: "https://127.0.0.1:0"},
+			c,
+			nil,
+		),
+		Scheme:                      c.Scheme(),
+		Recorder:                    record.NewFakeRecorder(100),
+		Config:                      nil,
+		ReconcilerCountPerNamespace: map[string]int{},
+	}
+}
+
+func drainRecorderEvents(recorder record.EventRecorder) []string {
+	fakeRecorder := recorder.(*record.FakeRecorder)
+
+	var events []string
+
+	for {
+		select {
+		case eventMessage := <-fakeRecorder.Events:
+			events = append(events, eventMessage)
+		default:
+			return events
+		}
+	}
+}
+
+func newDeletingTerminal(name, namespace, identifier, hostNamespace, targetNamespace string) *dashboardv1alpha1.Terminal {
+	return &dashboardv1alpha1.Terminal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{dashboardv1alpha1.TerminalName},
+		},
+		Spec: dashboardv1alpha1.TerminalSpec{
+			Identifier: identifier,
+			Host: dashboardv1alpha1.HostCluster{
+				Credentials: dashboardv1alpha1.ClusterCredentials{
+					ServiceAccountRef: &corev1.ObjectReference{Name: "host-sa", Namespace: hostNamespace},
+				},
+				Namespace: ptr.To(hostNamespace),
+				Pod: dashboardv1alpha1.Pod{
+					Container: &dashboardv1alpha1.Container{Image: "foo"},
+				},
+			},
+			Target: dashboardv1alpha1.TargetCluster{
+				Credentials: dashboardv1alpha1.ClusterCredentials{
+					ShootRef: &dashboardv1alpha1.ShootRef{Namespace: "garden-project", Name: "hibernated-shoot"},
+				},
+				Namespace:                  ptr.To(targetNamespace),
+				KubeconfigContextNamespace: "default",
+			},
+		},
+	}
+}
+
+var _ = Describe("Shoot Hibernation", func() {
+	Describe("IndexTerminalByShootRef", func() {
+		It("should return empty for terminal without shoot refs", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(BeEmpty())
+		})
+
+		It("should index target shoot ref", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/my-shoot"))
+		})
+
+		It("should index host shoot ref", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "host-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Name:      "sa",
+								Namespace: "ns",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/host-shoot"))
+		})
+
+		It("should index both host and target shoot refs when different", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "host-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "target-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/host-shoot", "garden-project/target-shoot"))
+		})
+
+		It("should deduplicate when host and target reference the same shoot", func() {
+			t := &dashboardv1alpha1.Terminal{
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "same-shoot",
+							},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "same-shoot",
+							},
+						},
+					},
+				},
+			}
+			keys := IndexTerminalByShootRef(t)
+			Expect(keys).To(ConsistOf("garden-project/same-shoot"))
+			Expect(keys).To(HaveLen(1))
+		})
+
+		It("should return nil for non-Terminal objects", func() {
+			keys := IndexTerminalByShootRef(&corev1.Pod{})
+			Expect(keys).To(BeNil())
+		})
+	})
+
+	Describe("shootWakeUpPredicate", func() {
+		var pred = shootWakeUpPredicate()
+
+		It("should reject create events", func() {
+			result := pred.Create(event.CreateEvent{
+				Object: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject delete events", func() {
+			result := pred.Delete(event.DeleteEvent{
+				Object: &gardencorev1beta1.Shoot{},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should accept update from hibernated to awake", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should reject update from awake to hibernated", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update when both awake", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: false},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update when both hibernated", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+				ObjectNew: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+				},
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should reject update with non-Shoot objects", func() {
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: &corev1.Pod{},
+				ObjectNew: &corev1.Pod{},
+			})
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Describe("mapShootToTerminals", func() {
+		It("should map a shoot to terminals referencing it", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-shoot",
+					Namespace: "garden-project",
+				},
+			}
+			terminal := &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-terminal",
+					Namespace: "term-ns",
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+						Namespace: ptr.To("term-ns"),
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: "garden-project",
+								Name:      "my-shoot",
+							},
+						},
+						Namespace:                  ptr.To("term-ns"),
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+
+			fakeClient := newFakeClientWithShoot(shoot, terminal)
+			r := newTestReconciler(fakeClient)
+
+			requests := r.mapShootToTerminals(context.Background(), shoot)
+
+			Expect(requests).To(ContainElement(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "term-ns",
+					Name:      "my-terminal",
+				},
+			}))
+		})
+
+		It("should return empty for a shoot not referenced by any terminal", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-shoot",
+					Namespace: "garden-project",
+				},
+			}
+
+			fakeClient := newFakeClientWithShoot(shoot)
+			r := newTestReconciler(fakeClient)
+
+			requests := r.mapShootToTerminals(context.Background(), shoot)
+
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Describe("newClientSetFromClusterCredentials", func() {
+		It("should return a hibernation error instead of creating a shoot client", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hibernated-shoot",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+			}
+			r := newTestReconciler(newFakeClientWithShoot(shoot))
+
+			clientSet, err := r.newClientSetFromClusterCredentials(context.Background(), r.ClientSet, dashboardv1alpha1.ClusterCredentials{
+				ShootRef: &dashboardv1alpha1.ShootRef{
+					Namespace: shoot.Namespace,
+					Name:      shoot.Name,
+				},
+			}, nil, nil)
+
+			Expect(clientSet).To(BeNil())
+			Expect(errors.Is(err, errShootHibernated)).To(BeTrue())
+			Expect(err).To(MatchError(errShootHibernated))
+		})
+	})
+
+	Describe("handleTerminal hibernation", func() {
+		It("should treat hibernated shoot as a wait state, not an error", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hibernated-shoot",
+					Namespace: "garden-project",
+				},
+				Status: gardencorev1beta1.ShootStatus{IsHibernated: true},
+			}
+
+			t := &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "terminal",
+					Namespace: "terminal-namespace",
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: shoot.Namespace,
+								Name:      shoot.Name,
+							},
+						},
+						Namespace: ptr.To("host-namespace"),
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: shoot.Namespace,
+								Name:      shoot.Name,
+							},
+						},
+						Namespace:                  ptr.To("target-namespace"),
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+
+			r := newTestReconciler(newFakeClientWithShoot(shoot, t))
+			r.Config = test.DefaultConfiguration()
+
+			result, err := r.handleTerminal(context.Background(), t)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Hour))
+
+			storedTerminal := &dashboardv1alpha1.Terminal{}
+			Expect(r.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, storedTerminal)).To(Succeed())
+			Expect(storedTerminal.Status.LastError).To(BeNil())
+			Expect(storedTerminal.Status.LastOperation).ToNot(BeNil())
+			Expect(storedTerminal.Status.LastOperation.Type).To(Equal(dashboardv1alpha1.LastOperationTypeReconcile))
+			Expect(storedTerminal.Status.LastOperation.State).To(Equal(dashboardv1alpha1.LastOperationStateProcessing))
+			Expect(storedTerminal.Status.LastOperation.Description).To(ContainSubstring("wake from hibernation"))
+		})
+	})
+
+	Describe("deleteTerminal hibernation", func() {
+		It("should clean up the awake cluster and keep the finalizer when the target shoot is hibernated", func() {
+			const (
+				terminalName      = "terminal"
+				terminalNamespace = "terminal-namespace"
+				hostNamespace     = "host-namespace"
+				targetNamespace   = "target-namespace"
+				identifier        = "abc123"
+			)
+
+			t := newDeletingTerminal(terminalName, terminalNamespace, identifier, hostNamespace, targetNamespace)
+			hostClient := newFakeClientWithObjects(
+				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.TerminalAttachResourceNamePrefix + identifier, Namespace: hostNamespace}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.TerminalAttachRoleResourceNamePrefix + identifier, Namespace: hostNamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.TerminalAttachResourceNamePrefix + identifier, Namespace: hostNamespace}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.TerminalPodResourceNamePrefix + identifier, Namespace: hostNamespace}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.KubeconfigSecretResourceNamePrefix + identifier, Namespace: hostNamespace}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dashboardv1alpha1.TokenSecretResourceNamePrefix + identifier, Namespace: hostNamespace}},
+			)
+			hostClientSet := gardenclient.NewClientSet(&rest.Config{}, hostClient, nil)
+			r := newTestReconciler(newFakeClientWithObjects(t.DeepCopy()))
+
+			result, err := r.deleteTerminal(
+				context.Background(),
+				t,
+				nil,
+				errShootHibernated,
+				nil,
+				hostClientSet,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Hour))
+
+			for _, deletedObject := range []struct {
+				key types.NamespacedName
+				obj client.Object
+			}{
+				{key: types.NamespacedName{Name: dashboardv1alpha1.TerminalAttachResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &corev1.ServiceAccount{}},
+				{key: types.NamespacedName{Name: dashboardv1alpha1.TerminalAttachRoleResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &rbacv1.Role{}},
+				{key: types.NamespacedName{Name: dashboardv1alpha1.TerminalAttachResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &rbacv1.RoleBinding{}},
+				{key: types.NamespacedName{Name: dashboardv1alpha1.TerminalPodResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &corev1.Pod{}},
+				{key: types.NamespacedName{Name: dashboardv1alpha1.KubeconfigSecretResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &corev1.Secret{}},
+				{key: types.NamespacedName{Name: dashboardv1alpha1.TokenSecretResourceNamePrefix + identifier, Namespace: hostNamespace}, obj: &corev1.Secret{}},
+			} {
+				Expect(kErros.IsNotFound(hostClient.Get(context.Background(), deletedObject.key, deletedObject.obj))).To(BeTrue())
+			}
+
+			storedTerminal := &dashboardv1alpha1.Terminal{}
+			Expect(r.Get(context.Background(), types.NamespacedName{Name: terminalName, Namespace: terminalNamespace}, storedTerminal)).To(Succeed())
+			Expect(storedTerminal.Finalizers).To(ContainElement(dashboardv1alpha1.TerminalName))
+			Expect(storedTerminal.Status.LastError).To(BeNil())
+			Expect(storedTerminal.Status.LastOperation).ToNot(BeNil())
+			Expect(storedTerminal.Status.LastOperation.Type).To(Equal(dashboardv1alpha1.LastOperationTypeDelete))
+			Expect(storedTerminal.Status.LastOperation.State).To(Equal(dashboardv1alpha1.LastOperationStateProcessing))
+
+			events := drainRecorderEvents(r.Recorder)
+			Expect(events).To(ContainElement(ContainSubstring("Normal Deleting Target cluster cleanup is deferred because the referenced shoot is hibernated")))
+			Expect(events).To(ContainElement(ContainSubstring("Normal Deleting Processing external dependency deletion")))
+			Expect(events).To(ContainElement(ContainSubstring("Normal Deleting External dependency deletion is waiting for deferred shoot cleanup")))
+			Expect(events).To(ContainElement(ContainSubstring("Warning Reconciling Could not clean up resources in target cluster")))
+			Expect(events).NotTo(ContainElement(ContainSubstring("Deleted available external dependencies")))
+			Expect(events).NotTo(ContainElement(ContainSubstring("Normal Hibernated")))
+		})
+	})
+
+	Describe("Shoot hibernation wake-up (integration)", func() {
+		const (
+			timeout  = time.Second * 30
+			interval = time.Millisecond * 250
+		)
+
+		var (
+			suffix            string
+			terminalNamespace string
+			hostNamespace     string
+			shootNamespace    string
+			shoot             *gardencorev1beta1.Shoot
+			terminal          *dashboardv1alpha1.Terminal
+			terminalKey       types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			suffix = test.StringWithCharset(randomLength, charset)
+			terminalNamespace = "test-hib-term-ns-" + suffix
+			hostNamespace = "test-hib-host-ns-" + suffix
+			shootNamespace = "garden-hib-" + suffix
+
+			By("Creating namespaces")
+
+			for _, ns := range []string{terminalNamespace, hostNamespace, shootNamespace} {
+				e.CreateObject(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, types.NamespacedName{Name: ns}, timeout, interval)
+			}
+
+			By("Creating host service account")
+			e.AddClusterAdminServiceAccount(ctx, "hib-host-sa", hostNamespace, timeout, interval)
+
+			By("Creating Project for Shoot namespace")
+
+			project := &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: "hib-" + suffix},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: &shootNamespace,
+				},
+			}
+			e.CreateObject(ctx, project, client.ObjectKeyFromObject(project), timeout, interval)
+
+			By("Creating Shoot")
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-shoot-" + suffix,
+					Namespace: shootNamespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: ptr.To("secretbinding"),
+					CloudProfileName:  ptr.To("cloudprofile1"),
+					Region:            "eu-central-1",
+					Provider: gardencorev1beta1.Provider{
+						Type: "foo-provider",
+						Workers: []gardencorev1beta1.Worker{
+							{
+								Name:    "cpu-worker",
+								Minimum: 1,
+								Maximum: 1,
+								Machine: gardencorev1beta1.Machine{
+									Type: "large",
+									Image: &gardencorev1beta1.ShootMachineImage{
+										Name:    "some-image",
+										Version: ptr.To("1.0.0"),
+									},
+								},
+							},
+						},
+					},
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.32.0",
+					},
+					Networking: &gardencorev1beta1.Networking{
+						Type: ptr.To("foo-networking"),
+					},
+				},
+			}
+			Expect(e.K8sClient.Create(ctx, shoot)).To(Succeed())
+
+			By("Setting Shoot status to hibernated")
+
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Status.IsHibernated = true
+			Expect(e.K8sClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+
+			By("Creating Terminal referencing the hibernated Shoot")
+
+			terminal = &dashboardv1alpha1.Terminal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hib-terminal-" + suffix,
+					Namespace: terminalNamespace,
+				},
+				Spec: dashboardv1alpha1.TerminalSpec{
+					Host: dashboardv1alpha1.HostCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ServiceAccountRef: &corev1.ObjectReference{
+								Kind:      rbacv1.ServiceAccountKind,
+								Name:      "hib-host-sa",
+								Namespace: hostNamespace,
+							},
+						},
+						Namespace: &hostNamespace,
+						Pod: dashboardv1alpha1.Pod{
+							Container: &dashboardv1alpha1.Container{Image: "foo"},
+						},
+					},
+					Target: dashboardv1alpha1.TargetCluster{
+						Credentials: dashboardv1alpha1.ClusterCredentials{
+							ShootRef: &dashboardv1alpha1.ShootRef{
+								Namespace: shootNamespace,
+								Name:      shoot.Name,
+							},
+						},
+						Namespace:                  &hostNamespace,
+						KubeconfigContextNamespace: "default",
+					},
+				},
+			}
+			terminalKey = types.NamespacedName{Name: terminal.Name, Namespace: terminal.Namespace}
+			Expect(e.K8sClient.Create(ctx, terminal)).To(Succeed())
+		})
+
+		It("should wait while shoot is hibernated, then reconcile after wake-up", func() {
+			By("Waiting for the terminal to report the hibernation wait state in LastOperation")
+			Eventually(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+				g.Expect(t.Status.LastError).To(BeNil())
+				g.Expect(t.Status.LastOperation).ToNot(BeNil())
+				g.Expect(t.Status.LastOperation.State).To(Equal(dashboardv1alpha1.LastOperationStateProcessing))
+				g.Expect(t.Status.LastOperation.Description).To(ContainSubstring("wake from hibernation"))
+			}, timeout, interval).Should(Succeed())
+
+			By("Ensuring the terminal is NOT progressing to ready state while hibernated")
+			Consistently(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+
+				g.Expect(t.Status.AttachServiceAccountName).To(BeNil())
+				g.Expect(t.Status.PodName).To(BeNil())
+			}, 3*time.Second, interval).Should(Succeed())
+
+			By("Waking the Shoot by clearing IsHibernated")
+
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Status.IsHibernated = false
+			Expect(e.K8sClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+
+			By("Waiting for the terminal to progress past hibernation wait state")
+			Eventually(func(g Gomega) {
+				t := &dashboardv1alpha1.Terminal{}
+				g.Expect(e.K8sClient.Get(ctx, terminalKey, t)).To(Succeed())
+				g.Expect(t.Status.LastOperation).ToNot(BeNil())
+				g.Expect(t.Status.LastOperation.Description).ToNot(ContainSubstring("hibernation"))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -24,11 +24,14 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -89,6 +92,17 @@ func main() {
 			BindAddress:    fmt.Sprintf("%s:%d", cmConfig.Server.Metrics.BindAddress, cmConfig.Server.Metrics.Port),
 			CertDir:        metricsServerCertDir,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
+		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&gardencorev1beta1.Shoot{}: {
+					// Transform strips Shoot objects down to the minimum fields needed
+					// by the terminal controller. Only metadata and status.isHibernated
+					// are preserved in the cache. If you need additional Shoot fields,
+					// add them here — otherwise cache reads return zero values silently.
+					Transform: transformShoot(),
+				},
+			},
 		},
 		LeaderElection:                ptr.Deref(cmConfig.LeaderElection.LeaderElect, true),
 		LeaderElectionResourceLock:    cmConfig.LeaderElection.ResourceLock,
@@ -183,6 +197,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Terminal{}, controllers.TerminalShootRef, controllers.IndexTerminalByShootRef); err != nil {
+		setupLog.Error(err, "unable to add terminal shoot ref field indexer")
+		os.Exit(1)
+	}
+
 	setupLog.Info("starting manager")
 
 	if err := mgr.Start(ctx); err != nil {
@@ -268,6 +287,29 @@ func readFile(configFile string, cfg *v1alpha1.ControllerManagerConfiguration) e
 	}
 
 	return json.Unmarshal(jsonData, cfg)
+}
+
+func transformShoot() toolscache.TransformFunc {
+	return func(obj interface{}) (interface{}, error) {
+		shoot, ok := obj.(*gardencorev1beta1.Shoot)
+		if !ok {
+			return obj, nil
+		}
+
+		stripped := &gardencorev1beta1.Shoot{
+			TypeMeta: shoot.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            shoot.Name,
+				Namespace:       shoot.Namespace,
+				ResourceVersion: shoot.ResourceVersion,
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				IsHibernated: shoot.Status.IsHibernated,
+			},
+		}
+
+		return stripped, nil
+	}
 }
 
 func validateConfig(cfg *v1alpha1.ControllerManagerConfiguration) error {

--- a/test/common.go
+++ b/test/common.go
@@ -157,6 +157,7 @@ func New(mutator admission.Handler, validator admission.Handler) Environment {
 			ControlPlaneStopTimeout:  2 * time.Minute,
 		},
 		GardenerAPIServer: &gardenenvtest.GardenerAPIServer{
+			Args:        []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator"},
 			StopTimeout: 2 * time.Minute,
 		},
 	}


### PR DESCRIPTION
/area robustness
/kind enhancement

**What this PR does / why we need it**:

When a Shoot referenced by a Terminal's host or target credentials is hibernated, the terminal controller now skips reconciliation and emits a `Hibernated` event. A Shoot watch with a wake-up predicate (`IsHibernated: true → false`) automatically re-enqueues affected Terminals when the Shoot comes back.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature operator
Terminal reconciliation is now skipped while a referenced Shoot is hibernated, reducing unnecessary errors and retries. Terminals are automatically re-reconciled when the Shoot wakes up.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal reconciliation now detects when a referenced Shoot is hibernated, records a “Hibernated” outcome, and pauses attach-related work until the Shoot wakes up.
  * Terminals are automatically re-queued on wake-up to resume reconciliation.
* **Bug Fixes**
  * Improved terminal status handling for clearer success/error states and more accurate “processing” updates.
  * Updated deletion behavior to defer external cleanup while the referenced Shoot is hibernated and retry later.
* **Tests**
  * Added coverage for hibernation wake-up and deferred deletion scenarios.
* **Chores**
  * Updated RBAC to allow watching Shoots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Replaces #511 (renamed branch due to cc-utils 50-char ref-length limit blocking image push).