### PR TITLE
ci: Enable automerge for gardener/gardener dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     ':semanticCommitsDisabled',
     'customManagers:githubActionsVersions',
     'github>gardener/ci-infra//config/renovate/group-gardener-updates.json5',
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ],
   labels: [
     'kind/enhancement',
@@ -13,6 +14,7 @@
     'gomodTidy',
   ],
   automergeStrategy: 'squash',
+  minimumReleaseAge: '3 days',
   customManagers: [
     {
       customType: 'regex',
@@ -28,8 +30,12 @@
   ],
   packageRules: [
     {
-      matchUpdateTypes: [
-        'patch',
+      matchDatasources: [
+        'go',
+      ],
+      matchPackageNames: [
+        'github.com/gardener/gardener',
+        'github.com/gardener/gardener/pkg/apis',
       ],
       automerge: true,
     },

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     with:
       mode: ${{ inputs.mode }}
     permissions:
@@ -33,7 +33,7 @@ jobs:
       id-token: write
     secrets:
       dockerhub-auth-token: ${{ secrets.dockerhub-auth-token }}
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     strategy:
       matrix:
         args:
@@ -86,7 +86,7 @@ jobs:
           task: ["check-generate", "lint", "go-test"]
       steps:
         - name: Trusted Checkout
-          uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+          uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
         - name: Set up Go
           uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
@@ -96,7 +96,7 @@ jobs:
 
         - name: Setup Git Identity
           if: matrix.task == 'check-generate'
-          uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+          uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
         - name: Run ${{ matrix.task }}
           shell: bash
@@ -107,7 +107,7 @@ jobs:
             tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
         - name: add-reports-to-component-descriptor
           if: ${{ matrix.task == 'go-test' }}
-          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+          uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
           with:
             blobs-directory: /tmp/blobs.d
             ocm-resources: |
@@ -122,7 +122,7 @@ jobs:
                     - test
 
   verify-sast:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       contents: read
     with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     secrets:


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

- Extend Renovate config with `automerge-with-tide.json5` preset to enable tide-compatible automerging
- Add automerge rule for `gardener/gardener` (and subpath modules like `pkg/apis`) updates
- Remove blanket patch automerge rule (was non-functional without tide preset, keeping it disabled intentionally for now)
- Add `minimumReleaseAge: 3 days` to avoid picking up releases before they've had time to surface issues

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings.
  * Enabled an additional automerge preset to streamline approved updates.
  * Added a 3-day minimum release age before updates are applied.
  * Adjusted update matching rules so Go module updates are handled more precisely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->